### PR TITLE
Fix #9, #12: Fixed IterableDataReader behavior.

### DIFF
--- a/src/Reader/IterableDataReader.php
+++ b/src/Reader/IterableDataReader.php
@@ -135,7 +135,11 @@ final class IterableDataReader implements DataReaderInterface, SortableDataInter
         $data = [];
         $skipped = 0;
 
-        foreach ($this->data as $item) {
+        $sortedData = $this->sort === null
+            ? $this->data
+            : $this->sortItems($this->data, $this->sort);
+
+        foreach ($sortedData as $item) {
             // do not return more than limit items
             if (count($data) === $this->limit) {
                 break;
@@ -153,10 +157,6 @@ final class IterableDataReader implements DataReaderInterface, SortableDataInter
             }
         }
 
-        if ($this->sort !== null) {
-            $data = $this->sortItems($data, $this->sort);
-        }
-
         return $data;
     }
 
@@ -169,7 +169,7 @@ final class IterableDataReader implements DataReaderInterface, SortableDataInter
 
     public function count(): int
     {
-        return count($this->data);
+        return count($this->read());
     }
 
     private function iterableToArray(iterable $iterable): array

--- a/tests/Reader/IterableDataReaderTest.php
+++ b/tests/Reader/IterableDataReaderTest.php
@@ -331,4 +331,35 @@ final class IterableDataReaderTest extends TestCase
             ],
         ], $reader->read());
     }
+
+    public function testLimitedSort(): void
+    {
+        $readerMin = (new IterableDataReader($this->getDataSet()))
+            ->withSort(
+                (new Sort(['id']))->withOrder(['id' => 'asc'])
+            )
+            ->withLimit(1);
+        $min = $readerMin->read()[0]['id'];
+        $this->assertSame(1, $min, 'Wrong min value found');
+
+        $readerMax = (new IterableDataReader($this->getDataSet()))
+            ->withSort(
+                (new Sort(['id']))->withOrder(['id' => 'desc'])
+            )
+            ->withLimit(1);
+        $max = $readerMax->read()[0]['id'];
+        $this->assertSame(6, $max, 'Wrong max value found');
+    }
+
+    public function testFilteredCount(): void
+    {
+        $reader = new IterableDataReader($this->getDataSet());
+        $total = count($reader);
+
+        $this->assertSame(5, $total, 'Wrong count of elements');
+
+        $reader = $reader->withFilter(new Like('name', 'agent'));
+        $totalAgents = count($reader);
+        $this->assertSame(2, $totalAgents, 'Wrong count of filtered elements');
+    }
 }


### PR DESCRIPTION
* Sort before slice instead of sorting sliced items.
* Count filtered items instead of count all dataset.

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Tests pass?   | ✔️
| Fixed issues  | #9, #12 
Also covers #10 PR