### PR TITLE
#21 PaginatorInterface

### DIFF
--- a/src/Paginator/KeysetPaginator.php
+++ b/src/Paginator/KeysetPaginator.php
@@ -201,7 +201,7 @@ class KeysetPaginator implements PaginatorInterface
             // Initial state, no values.
             return true;
         }
-        if ($this->firstValue !== null && $this->getCurrentPageSize() < $this->pageSize) {
+        if ($this->getCurrentPageSize() < $this->pageSize) {
             // The page size is smaller than the specified size and goes to the previous page.
             return true;
         }

--- a/src/Paginator/KeysetPaginator.php
+++ b/src/Paginator/KeysetPaginator.php
@@ -108,7 +108,7 @@ class KeysetPaginator implements PaginatorInterface
             $filter = null;
             if ($sorting === 'asc') {
                 $filter = new GreaterThan($field, $value);
-            } elseif ($sorting === 'desc') {
+            } else {
                 $filter = new LessThan($field, $value);
             }
 
@@ -252,6 +252,7 @@ class KeysetPaginator implements PaginatorInterface
         if ($data instanceof \Traversable && !($data instanceof \Countable)) {
             $data = iterator_to_array($data);
         }
+        foreach($data as $void);    // Always read all the data.
         $this->readCache = $data;
     }
 }

--- a/src/Paginator/KeysetPaginator.php
+++ b/src/Paginator/KeysetPaginator.php
@@ -150,30 +150,32 @@ class KeysetPaginator implements PaginatorInterface
         return $new;
     }
 
-    /**
-     * Token for the previous page.
-     *
-     * This method allows to continue paging when a new record is created.
-     *
-     * @return string|null
-     */
     public function getPreviousPageToken(): ?string
     {
         $this->initReadCache();
-        return (string)($this->currentFirstValue ?? $this->firstValue);
+        $currentPageSize = $this->getCurrentPageSize();
+        if($this->lastValue !== null && $currentPageSize === 0) {
+            throw new \RuntimeException('Previous page token cannot be determined.');
+        } elseif($this->lastValue !== null && $currentPageSize < $this->pageSize) {
+            return (string) $this->currentFirstValue;
+        } elseif ($this->currentFirstValue === null || $currentPageSize !== $this->pageSize) {
+            return null;
+        }
+        return (string)$this->currentFirstValue;
     }
 
-    /**
-     * Token for the next page.
-     *
-     * This method allows to continue paging when a new record is created.
-     *
-     * @return string|null
-     */
     public function getNextPageToken(): ?string
     {
         $this->initReadCache();
-        return (string)($this->currentLastValue ?? $this->lastValue);
+        $currentPageSize = $this->getCurrentPageSize();
+        if ($this->firstValue !== null && $currentPageSize === 0) {
+            throw new \RuntimeException('Next page token cannot be determined.');
+        } elseif ($this->firstValue !== null && $currentPageSize < $this->pageSize) {
+            return (string)$this->currentLastValue;
+        } elseif ($this->currentLastValue === null || $currentPageSize !== $this->pageSize) {
+            return null;
+        }
+        return (string)$this->currentLastValue;
     }
 
     public function withPageSize(int $pageSize)
@@ -252,7 +254,7 @@ class KeysetPaginator implements PaginatorInterface
         if ($data instanceof \Traversable && !($data instanceof \Countable)) {
             $data = iterator_to_array($data);
         }
-        foreach($data as $void);    // Always read all the data.
+        foreach ($data as $void) ;    // Always read all the data.
         $this->readCache = $data;
     }
 }

--- a/src/Paginator/KeysetPaginator.php
+++ b/src/Paginator/KeysetPaginator.php
@@ -190,13 +190,33 @@ class KeysetPaginator implements PaginatorInterface
 
     public function isOnLastPage(): bool
     {
-        throw new \RuntimeException('The last page cannot be determined.');
+        if ($this->firstValue !== null) {
+            throw new \RuntimeException('The last page cannot be determined.');
+        }
+        $currentPageSize = $this->getCurrentPageSize();
+        if ($this->lastValue !== null) {
+            // going forward
+            return $currentPageSize !== $this->pageSize;
+        } elseif ($this->firstValue === null && $this->lastValue === null && $currentPageSize !== $this->pageSize) {
+            // first page and the number of pages is 1.
+            return true;
+        }
+        return false;
     }
 
     public function isOnFirstPage(): bool
     {
         if ($this->lastValue === null && $this->firstValue === null) {
             // Initial state, no values.
+            return true;
+        }
+        $currentPageSize = $this->getCurrentPageSize();
+
+        if ($this->firstValue === null && $this->lastValue === null && $currentPageSize !== $this->pageSize) {
+            // first page and the number of pages is 1.
+            return true;
+        } elseif ($this->firstValue !== null && $currentPageSize !== $this->pageSize) {
+            // going backward
             return true;
         }
         throw new \RuntimeException('The first page cannot be determined.');
@@ -225,7 +245,7 @@ class KeysetPaginator implements PaginatorInterface
      */
     protected function initReadCache(): void
     {
-        if($this->readCache !== null) {
+        if ($this->readCache !== null) {
             return;
         }
         $data = $this->read();

--- a/src/Paginator/KeysetPaginator.php
+++ b/src/Paginator/KeysetPaginator.php
@@ -197,12 +197,12 @@ class KeysetPaginator implements PaginatorInterface
 
     public function isOnFirstPage(): bool
     {
-        if ($this->getCurrentPageSize() < $this->pageSize && $this->firstValue !== null) {
-            // The page size is smaller than the specified size and goes to the previous page.
-            return true;
-        }
         if ($this->lastValue === null && $this->firstValue === null) {
             // Initial state, no values.
+            return true;
+        }
+        if ($this->firstValue !== null && $this->getCurrentPageSize() < $this->pageSize) {
+            // The page size is smaller than the specified size and goes to the previous page.
             return true;
         }
         return false;

--- a/src/Paginator/KeysetPaginator.php
+++ b/src/Paginator/KeysetPaginator.php
@@ -153,7 +153,6 @@ class KeysetPaginator implements PaginatorInterface
     /**
      * Token for the previous page.
      *
-     * The token of the previous page may be available even if the return value of {@see isOnFirstPage()} is true.
      * This method allows to continue paging when a new record is created.
      *
      * @return string|null
@@ -167,7 +166,6 @@ class KeysetPaginator implements PaginatorInterface
     /**
      * Token for the next page.
      *
-     * The token of the next page may be available even if the return value of {@see isOnLastPage()} is true.
      * This method allows to continue paging when a new record is created.
      *
      * @return string|null
@@ -192,7 +190,7 @@ class KeysetPaginator implements PaginatorInterface
 
     public function isOnLastPage(): bool
     {
-        return !$this->isOnFirstPage() && $this->getCurrentPageSize() !== $this->pageSize;
+        throw new \RuntimeException('The last page cannot be determined.');
     }
 
     public function isOnFirstPage(): bool
@@ -201,11 +199,7 @@ class KeysetPaginator implements PaginatorInterface
             // Initial state, no values.
             return true;
         }
-        if ($this->getCurrentPageSize() < $this->pageSize) {
-            // The page size is smaller than the specified size and goes to the previous page.
-            return true;
-        }
-        return false;
+        throw new \RuntimeException('The first page cannot be determined.');
     }
 
     public function getCurrentPageSize(): int

--- a/src/Paginator/KeysetPaginator.php
+++ b/src/Paginator/KeysetPaginator.php
@@ -36,7 +36,7 @@ class KeysetPaginator implements PaginatorInterface
     private $currentLastValue;
 
     /**
-     * @var iterable|null Reader cache against repeated scans.
+     * @var array|null Reader cache against repeated scans.
      *
      * See more {@see resetReadCache()} and {@see initReadCache()}.
      */
@@ -132,7 +132,7 @@ class KeysetPaginator implements PaginatorInterface
         return $this->readCache = $data;
     }
 
-    public function withPreviousPageToken($value)
+    public function withPreviousPageToken(string $value)
     {
         $new = clone $this;
         $new->firstValue = $value;
@@ -141,7 +141,7 @@ class KeysetPaginator implements PaginatorInterface
         return $new;
     }
 
-    public function withNextPageToken($value)
+    public function withNextPageToken(string $value)
     {
         $new = clone $this;
         $new->firstValue = null;

--- a/src/Paginator/KeysetPaginator.php
+++ b/src/Paginator/KeysetPaginator.php
@@ -36,7 +36,7 @@ class KeysetPaginator implements PaginatorInterface
     private $currentLastValue;
 
     /**
-     * @var iterable Reader cache against repeated scans.
+     * @var iterable|null Reader cache against repeated scans.
      *
      * See more {@see clearReadCache()}.
      */

--- a/src/Paginator/KeysetPaginator.php
+++ b/src/Paginator/KeysetPaginator.php
@@ -132,7 +132,7 @@ class KeysetPaginator implements PaginatorInterface
         return $this->readCache = $data;
     }
 
-    public function withPreviousPageToken($value): PaginatorInterface
+    public function withPreviousPageToken($value)
     {
         $new = clone $this;
         $new->firstValue = $value;
@@ -141,7 +141,7 @@ class KeysetPaginator implements PaginatorInterface
         return $new;
     }
 
-    public function withNextPageToken($value): PaginatorInterface
+    public function withNextPageToken($value)
     {
         $new = clone $this;
         $new->firstValue = null;
@@ -176,7 +176,7 @@ class KeysetPaginator implements PaginatorInterface
         return (string)($this->currentLastValue ?? $this->lastValue);
     }
 
-    public function withPageSize(int $pageSize): PaginatorInterface
+    public function withPageSize(int $pageSize)
     {
         if ($pageSize < 1) {
             throw new \InvalidArgumentException('Page size should be at least 1');

--- a/src/Paginator/KeysetPaginator.php
+++ b/src/Paginator/KeysetPaginator.php
@@ -38,7 +38,7 @@ class KeysetPaginator implements PaginatorInterface
     /**
      * @var iterable Reader cache against repeated scans.
      *
-     * See more [[clearReadCache]].
+     * See more {@see clearReadCache()}.
      */
     private $readCache;
 

--- a/src/Paginator/OffsetPaginator.php
+++ b/src/Paginator/OffsetPaginator.php
@@ -63,7 +63,7 @@ final class OffsetPaginator implements PaginatorInterface
         return $new;
     }
 
-    public function withPageSize(int $size): PaginatorInterface
+    public function withPageSize(int $size)
     {
         if ($size < 1) {
             throw new \InvalidArgumentException('Page size should be at least 1');
@@ -159,6 +159,7 @@ final class OffsetPaginator implements PaginatorInterface
         if ($data instanceof \Traversable && !($data instanceof \Countable)) {
             $data = iterator_to_array($data);
         }
+        foreach($data as $void);    // Always read all the data.
         $this->readCache = $data;
     }
 }

--- a/src/Paginator/OffsetPaginator.php
+++ b/src/Paginator/OffsetPaginator.php
@@ -21,15 +21,15 @@ final class OffsetPaginator implements PaginatorInterface
     private $pageSize = self::DEFAULT_PAGE_SIZE;
 
     /**
-     * @var iterable|null Reader cache against repeated scans.
+     * @var array|null Reader cache against repeated scans.
      *
-     * See more {@see resetCache()} and {@see initCache()}.
+     * See more {@see resetInternal()} and {@see initializeInternal()}.
      */
     private $readCache;
     /**
      * @var int|null Total count cache against repeated scans.
      *
-     * See more {@see resetCache()} and {@see initCache()}.
+     * See more {@see initializeInternal()}.
      */
     private $totalCountCache;
 
@@ -58,7 +58,6 @@ final class OffsetPaginator implements PaginatorInterface
         }
 
         $new = clone $this;
-        $new->resetCache();
         $new->currentPage = $page;
         return $new;
     }
@@ -70,7 +69,6 @@ final class OffsetPaginator implements PaginatorInterface
         }
 
         $new = clone $this;
-        $new->resetCache();
         $new->pageSize = $size;
         return $new;
     }
@@ -130,36 +128,25 @@ final class OffsetPaginator implements PaginatorInterface
 
     public function getCurrentPageSize(): int
     {
-        $this->initCache();
+        $this->initializeInternal();
         return count($this->readCache);
     }
 
-    /**
-     * Reset the read cache
-     *
-     * Properties of this object using the read cache are to prevent duplicate reads. However,
-     * for these properties to work properly after changing the parameters, it is need to clear the cache.
-     * Therefore, it is important that you call this method if you change the default parameters.
-     */
-    protected function resetCache(): void
+    public function __clone()
     {
         $this->readCache = null;
         $this->totalCountCache = null;
     }
 
-    /**
-     * Initializes the reading cache
-     */
-    protected function initCache(): void
+    protected function initializeInternal(): void
     {
         if($this->readCache !== null) {
             return;
         }
-        $data = $this->read();
-        if ($data instanceof \Traversable && !($data instanceof \Countable)) {
-            $data = iterator_to_array($data);
+        $cache = [];
+        foreach ($this->read() as $value) {
+            $cache[] = $value;
         }
-        foreach($data as $void);    // Always read all the data.
-        $this->readCache = $data;
+        $this->readCache = $cache;
     }
 }

--- a/src/Paginator/OffsetPaginator.php
+++ b/src/Paginator/OffsetPaginator.php
@@ -23,7 +23,7 @@ final class OffsetPaginator implements PaginatorInterface
     /**
      * @var array|null Reader cache against repeated scans.
      *
-     * See more {@see resetInternal()} and {@see initializeInternal()}.
+     * @see initializeInternal()
      */
     private $readCache;
     /**

--- a/src/Paginator/OffsetPaginator.php
+++ b/src/Paginator/OffsetPaginator.php
@@ -51,7 +51,7 @@ final class OffsetPaginator implements PaginatorInterface
         return $this->currentPage;
     }
 
-    public function withCurrentPage(int $page): self
+    public function withCurrentPage(int $page)
     {
         if ($page < 1) {
             throw new \InvalidArgumentException('Current page should be at least 1');
@@ -118,12 +118,12 @@ final class OffsetPaginator implements PaginatorInterface
         return $this->isOnFirstPage() ? null : (string) ($this->currentPage - 1);
     }
 
-    public function withNextPageToken(?string $token): PaginatorInterface
+    public function withNextPageToken(?string $token)
     {
         return $this->withCurrentPage(intval($token));
     }
 
-    public function withPreviousPageToken(?string $token): PaginatorInterface
+    public function withPreviousPageToken(?string $token)
     {
         return $this->withCurrentPage(intval($token));
     }

--- a/src/Paginator/OffsetPaginator.php
+++ b/src/Paginator/OffsetPaginator.php
@@ -10,7 +10,7 @@ use Yiisoft\Data\Reader\OffsetableDataInterface;
 /**
  * OffsetPaginator
  */
-final class OffsetPaginator
+final class OffsetPaginator implements PaginatorInterface
 {
     /**
      * @var OffsetableDataInterface|DataReaderInterface|CountableDataInterface
@@ -18,7 +18,7 @@ final class OffsetPaginator
     private $dataReader;
 
     private $currentPage = 1;
-    private $pageSize = 10;
+    private $pageSize = self::DEFAULT_PAGE_SIZE;
 
     public function __construct(DataReaderInterface $dataReader)
     {
@@ -49,7 +49,7 @@ final class OffsetPaginator
         return $new;
     }
 
-    public function withPageSize(int $size): self
+    public function withPageSize(int $size): PaginatorInterface
     {
         if ($size < 1) {
             throw new \InvalidArgumentException('Page size should be at least 1');
@@ -84,5 +84,25 @@ final class OffsetPaginator
     {
         $reader = $this->dataReader->withLimit($this->pageSize)->withOffset($this->getOffset());
         yield from $reader->read();
+    }
+
+    public function getNextPageToken(): ?string
+    {
+        return $this->isOnLastPage() ? null : (string) ($this->currentPage + 1);
+    }
+
+    public function getPreviousPageToken(): ?string
+    {
+        return $this->isOnFirstPage() ? null : (string) ($this->currentPage - 1);
+    }
+
+    public function withNextPageToken(?string $token): PaginatorInterface
+    {
+        return $this->withCurrentPage(intval($token));
+    }
+
+    public function withPreviousPageToken(?string $token): PaginatorInterface
+    {
+        return $this->withCurrentPage(intval($token));
     }
 }

--- a/src/Paginator/PaginatorInterface.php
+++ b/src/Paginator/PaginatorInterface.php
@@ -16,4 +16,5 @@ interface PaginatorInterface
     public function withNextPageToken(?string $token): self;
     public function withPreviousPageToken(?string $token): self;
     public function withPageSize(int $limit): self;
+    public function getCurrentPageSize(): int;
 }

--- a/src/Paginator/PaginatorInterface.php
+++ b/src/Paginator/PaginatorInterface.php
@@ -1,0 +1,19 @@
+<?php
+declare(strict_types=1);
+
+namespace Yiisoft\Data\Paginator;
+
+
+interface PaginatorInterface
+{
+    public const DEFAULT_PAGE_SIZE = 10;
+
+    public function read(): iterable;
+    public function isOnLastPage(): bool;
+    public function isOnFirstPage(): bool;
+    public function getNextPageToken(): ?string;
+    public function getPreviousPageToken(): ?string;
+    public function withNextPageToken(?string $token): self;
+    public function withPreviousPageToken(?string $token): self;
+    public function withPageSize(int $limit): self;
+}

--- a/src/Paginator/PaginatorInterface.php
+++ b/src/Paginator/PaginatorInterface.php
@@ -13,8 +13,17 @@ interface PaginatorInterface
     public function isOnFirstPage(): bool;
     public function getNextPageToken(): ?string;
     public function getPreviousPageToken(): ?string;
-    public function withNextPageToken(?string $token): self;
-    public function withPreviousPageToken(?string $token): self;
-    public function withPageSize(int $limit): self;
+    /**
+     * @return static
+     */
+    public function withNextPageToken(?string $token);
+    /**
+     * @return static
+     */
+    public function withPreviousPageToken(?string $token);
+    /**
+     * @return static
+     */
+    public function withPageSize(int $limit);
     public function getCurrentPageSize(): int;
 }

--- a/src/Reader/FilterableDataInterface.php
+++ b/src/Reader/FilterableDataInterface.php
@@ -7,5 +7,8 @@ use Yiisoft\Data\Reader\Filter\FilterInterface;
 
 interface FilterableDataInterface
 {
+    /**
+     * @return static
+     */
     public function withFilter(FilterInterface $filter);
 }

--- a/tests/Paginator/KeysetPaginatorTest.php
+++ b/tests/Paginator/KeysetPaginatorTest.php
@@ -147,7 +147,6 @@ final class KeysetPaginatorTest extends Testcase
         $last = end($expected);
         $this->assertSame((string)$last['id'], $paginator->getNextPageToken());
         $this->assertSame(true, $paginator->isOnFirstPage());
-        $this->assertSame(false, $paginator->isOnLastPage());
     }
 
     public function testReadSecondPage(): void
@@ -175,8 +174,6 @@ final class KeysetPaginatorTest extends Testcase
         $this->assertSame($expected, $this->iterableToArray($paginator->read()));
         $last = end($expected);
         $this->assertSame((string)$last['id'], $paginator->getNextPageToken());
-        $this->assertSame(false, $paginator->isOnFirstPage());
-        $this->assertSame(false, $paginator->isOnLastPage());
     }
 
     public function testReadSecondPageOrderedByName(): void
@@ -204,8 +201,6 @@ final class KeysetPaginatorTest extends Testcase
         $this->assertSame($expected, $this->iterableToArray($paginator->read()));
         $last = end($expected);
         $this->assertSame((string)$last['name'], $paginator->getNextPageToken());
-        $this->assertSame(false, $paginator->isOnFirstPage());
-        $this->assertSame(false, $paginator->isOnLastPage());
     }
 
     public function testBackwardPagination(): void
@@ -234,8 +229,6 @@ final class KeysetPaginatorTest extends Testcase
         $last = end($expected);
         $this->assertSame((string)$last['id'], $paginator->getNextPageToken(), 'Last value fail!');
         $this->assertSame((string)$first['id'], $paginator->getPreviousPageToken(), 'First value fail!');
-        $this->assertSame(false, $paginator->isOnFirstPage());
-        $this->assertSame(false, $paginator->isOnLastPage());
     }
 
     public function testForwardAndBackwardPagination(): void
@@ -264,8 +257,6 @@ final class KeysetPaginatorTest extends Testcase
         $last = end($expected);
         $this->assertSame((string)$last['id'], $paginator->getNextPageToken(), 'Last value fail!');
         $this->assertSame((string)$first['id'], $paginator->getPreviousPageToken(), 'First value fail!');
-        $this->assertSame(false, $paginator->isOnFirstPage());
-        $this->assertSame(false, $paginator->isOnLastPage());
 
         $expected = [
             [
@@ -287,8 +278,6 @@ final class KeysetPaginatorTest extends Testcase
         $last = end($expected);
         $this->assertSame((string)$last['id'], $paginator->getNextPageToken(), 'Last value fail!');
         $this->assertSame((string)$first['id'], $paginator->getPreviousPageToken(), 'First value fail!');
-        $this->assertSame(false, $paginator->isOnFirstPage());
-        $this->assertSame(false, $paginator->isOnLastPage());
     }
 
     public function testIsOnFirstPage(): void
@@ -300,17 +289,9 @@ final class KeysetPaginatorTest extends Testcase
             ->withPageSize(2);
         $this->assertSame(true, $paginator->isOnFirstPage());
 
-        foreach (range(1, 10) as $void) {
-            $paginator = $paginator->withNextPageToken($paginator->getNextPageToken());
-            $this->assertSame(false, $paginator->isOnFirstPage());
-        }
-
+        $this->expectException(\RuntimeException::class);
         $paginator = $paginator->withPreviousPageToken("1");
-        $this->assertSame(true, $paginator->isOnFirstPage());
-        $paginator = $paginator->withPreviousPageToken("2");
-        $this->assertSame(true, $paginator->isOnFirstPage());
-        $paginator = $paginator->withPreviousPageToken("3");
-        $this->assertSame(false, $paginator->isOnFirstPage());
+        $paginator->isOnFirstPage();
     }
 
     public function testIsOnLastPage(): void
@@ -320,14 +301,8 @@ final class KeysetPaginatorTest extends Testcase
             ->withSort($sort);
         $paginator = (new KeysetPaginator($dataReader))
             ->withPageSize(2);
-
-        $this->assertSame(false, $paginator->isOnLastPage());
-        $paginator = $paginator->withNextPageToken("6");
-        $this->assertSame(true, $paginator->isOnLastPage());
-        $paginator = $paginator->withNextPageToken("5");
-        $this->assertSame(true, $paginator->isOnLastPage());
-        $paginator = $paginator->withNextPageToken("4");
-        $this->assertSame(false, $paginator->isOnLastPage());
+        $this->expectException(\RuntimeException::class);
+        $paginator->isOnLastPage();
     }
 
     public function testCurrentPageSize(): void

--- a/tests/Paginator/KeysetPaginatorTest.php
+++ b/tests/Paginator/KeysetPaginatorTest.php
@@ -381,4 +381,46 @@ final class KeysetPaginatorTest extends Testcase
         $this->assertSame(2, $dataSet->getRewindCounter());
     }
 
+    public function testTokenResults():void {
+        $sort = (new Sort(['id']))->withOrderString('id');
+        $dataReader = (new IterableDataReader($this->getDataSet()))
+            ->withSort($sort);
+        $paginator = (new KeysetPaginator($dataReader))
+            ->withPageSize(2);
+        $this->assertNotNull($paginator->getNextPageToken());
+        $paginator = $paginator->withPreviousPageToken("1");
+        try {
+            $paginator->getNextPageToken();
+            $this->assertTrue(false);
+        } catch(\RuntimeException $e) {
+            $this->assertTrue(true);
+        }
+        $this->assertNull($paginator->getPreviousPageToken());
+        $paginator = $paginator->withPreviousPageToken("2");
+        $this->assertNotNull($paginator->getNextPageToken());
+        $this->assertSame("1", $paginator->getNextPageToken());
+        $this->assertNull($paginator->getPreviousPageToken());
+        $paginator = $paginator->withPreviousPageToken("3");
+        $this->assertNotNull($paginator->getNextPageToken());
+        $this->assertSame("2", $paginator->getNextPageToken());
+        $this->assertNotNull($paginator->getPreviousPageToken());
+
+        $paginator = $paginator->withNextPageToken("6");
+        try {
+            $paginator->getPreviousPageToken();
+            $this->assertTrue(false);
+        } catch(\RuntimeException $e) {
+            $this->assertTrue(true);
+        }
+        $this->assertNull($paginator->getNextPageToken());
+        $paginator = $paginator->withNextPageToken("5");
+        $this->assertNotNull($paginator->getPreviousPageToken());
+        $this->assertSame("6", $paginator->getPreviousPageToken());
+        $this->assertNull($paginator->getNextPageToken());
+        $paginator = $paginator->withNextPageToken("4");
+        $this->assertNotNull($paginator->getPreviousPageToken());
+        $this->assertSame("5", $paginator->getPreviousPageToken());
+        $this->assertNotNull($paginator->getNextPageToken());
+    }
+
 }

--- a/tests/Paginator/KeysetPaginatorTest.php
+++ b/tests/Paginator/KeysetPaginatorTest.php
@@ -113,7 +113,7 @@ final class KeysetPaginatorTest extends Testcase
 
         $paginator = (new KeysetPaginator($dataReader))
             ->withPageSize(2)
-            ->withLast(3);
+            ->withNextPageToken(3);
 
         $this->expectException(\RuntimeException::class);
 
@@ -144,7 +144,7 @@ final class KeysetPaginatorTest extends Testcase
 
         $this->assertSame($expected, $this->iterableToArray($paginator->read()));
         $last = end($expected);
-        $this->assertSame($last['id'], $paginator->getLast());
+        $this->assertSame((string)$last['id'], $paginator->getNextPageToken());
     }
 
     public function testReadSecondPage(): void
@@ -156,7 +156,7 @@ final class KeysetPaginatorTest extends Testcase
 
         $paginator = (new KeysetPaginator($dataReader))
             ->withPageSize(2)
-            ->withLast(2);
+            ->withNextPageToken(2);
 
         $expected = [
             [
@@ -171,7 +171,7 @@ final class KeysetPaginatorTest extends Testcase
 
         $this->assertSame($expected, $this->iterableToArray($paginator->read()));
         $last = end($expected);
-        $this->assertSame($last['id'], $paginator->getLast());
+        $this->assertSame((string)$last['id'], $paginator->getNextPageToken());
     }
 
     public function testReadSecondPageOrderedByName(): void
@@ -183,7 +183,7 @@ final class KeysetPaginatorTest extends Testcase
 
         $paginator = (new KeysetPaginator($dataReader))
             ->withPageSize(2)
-            ->withLast( 'Agent J');
+            ->withNextPageToken('Agent J');
 
         $expected = [
             [
@@ -198,7 +198,7 @@ final class KeysetPaginatorTest extends Testcase
 
         $this->assertSame($expected, $this->iterableToArray($paginator->read()));
         $last = end($expected);
-        $this->assertSame($last['name'], $paginator->getLast());
+        $this->assertSame((string)$last['name'], $paginator->getNextPageToken());
     }
 
     public function testBackwardPagination(): void
@@ -210,7 +210,7 @@ final class KeysetPaginatorTest extends Testcase
 
         $paginator = (new KeysetPaginator($dataReader))
             ->withPageSize(2)
-            ->withFirst(5);
+            ->withPreviousPageToken(5);
 
         $expected = [
             [
@@ -225,8 +225,8 @@ final class KeysetPaginatorTest extends Testcase
         $this->assertSame($expected, $this->iterableToArray($paginator->read()));
         $first = reset($expected);
         $last = end($expected);
-        $this->assertSame($last['id'], $paginator->getLast(), 'Last value fail!');
-        $this->assertSame($first['id'], $paginator->getFirst(), 'First value fail!');
+        $this->assertSame((string)$last['id'], $paginator->getNextPageToken(), 'Last value fail!');
+        $this->assertSame((string)$first['id'], $paginator->getPreviousPageToken(), 'First value fail!');
     }
 
     public function testForwardAndBackwardPagination(): void
@@ -238,7 +238,7 @@ final class KeysetPaginatorTest extends Testcase
 
         $paginator = (new KeysetPaginator($dataReader))
             ->withPageSize(2)
-            ->withLast(2);
+            ->withNextPageToken(2);
 
         $expected = [
             [
@@ -253,8 +253,8 @@ final class KeysetPaginatorTest extends Testcase
         $this->assertSame($expected, $this->iterableToArray($paginator->read()));
         $first = reset($expected);
         $last = end($expected);
-        $this->assertSame($last['id'], $paginator->getLast(), 'Last value fail!');
-        $this->assertSame($first['id'], $paginator->getFirst(), 'First value fail!');
+        $this->assertSame((string)$last['id'], $paginator->getNextPageToken(), 'Last value fail!');
+        $this->assertSame((string)$first['id'], $paginator->getPreviousPageToken(), 'First value fail!');
 
         $expected = [
             [
@@ -269,12 +269,12 @@ final class KeysetPaginatorTest extends Testcase
 
         $paginator = (new KeysetPaginator($dataReader))
             ->withPageSize(2)
-            ->withFirst($paginator->getFirst());
+            ->withPreviousPageToken($paginator->getPreviousPageToken());
 
         $this->assertSame($expected, $this->iterableToArray($paginator->read()));
         $first = reset($expected);
         $last = end($expected);
-        $this->assertSame($last['id'], $paginator->getLast(), 'Last value fail!');
-        $this->assertSame($first['id'], $paginator->getFirst(), 'First value fail!');
+        $this->assertSame((string)$last['id'], $paginator->getNextPageToken(), 'Last value fail!');
+        $this->assertSame((string)$first['id'], $paginator->getPreviousPageToken(), 'First value fail!');
     }
 }

--- a/tests/Paginator/KeysetPaginatorTest.php
+++ b/tests/Paginator/KeysetPaginatorTest.php
@@ -311,7 +311,6 @@ final class KeysetPaginatorTest extends Testcase
             ->withPreviousPageToken($paginator->getPreviousPageToken());
 
         $this->assertSame($expected, $this->iterableToArray($paginator->read()));
-        $first = reset($expected);
         $last = end($expected);
         $this->assertSame((string)$last['id'], $paginator->getNextPageToken(), 'Last value fail!');
         $this->assertNull($paginator->getPreviousPageToken(), 'First value fail!');

--- a/tests/Paginator/KeysetPaginatorTest.php
+++ b/tests/Paginator/KeysetPaginatorTest.php
@@ -288,10 +288,6 @@ final class KeysetPaginatorTest extends Testcase
         $paginator = (new KeysetPaginator($dataReader))
             ->withPageSize(2);
         $this->assertSame(true, $paginator->isOnFirstPage());
-
-        $this->expectException(\RuntimeException::class);
-        $paginator = $paginator->withPreviousPageToken("1");
-        $paginator->isOnFirstPage();
     }
 
     public function testIsOnLastPage(): void
@@ -301,8 +297,19 @@ final class KeysetPaginatorTest extends Testcase
             ->withSort($sort);
         $paginator = (new KeysetPaginator($dataReader))
             ->withPageSize(2);
-        $this->expectException(\RuntimeException::class);
-        $paginator->isOnLastPage();
+
+        try {
+            $paginator->isOnLastPage();
+            $this->assertTrue(false);
+        } catch(\RuntimeException $e) {
+            $this->assertTrue(true);
+        }
+        $paginator = $paginator->withNextPageToken("6");
+        $this->assertSame(true, $paginator->isOnLastPage());
+        $paginator = $paginator->withNextPageToken("5");
+        $this->assertSame(true, $paginator->isOnLastPage());
+        $paginator = $paginator->withNextPageToken("4");
+        $this->assertSame(false, $paginator->isOnLastPage());
     }
 
     public function testCurrentPageSize(): void

--- a/tests/Paginator/KeysetPaginatorTest.php
+++ b/tests/Paginator/KeysetPaginatorTest.php
@@ -121,6 +121,43 @@ final class KeysetPaginatorTest extends Testcase
         $this->iterableToArray($paginator->read());
     }
 
+    /**
+     * @dataProvider onePageDataProvider
+     */
+    public function testOnePage(array $dataSet, int $pageSize): void
+    {
+        $sort = (new Sort(['id', 'name']))->withOrderString('id');
+
+        $dataReader = (new IterableDataReader($dataSet))
+            ->withSort($sort);
+        $paginator = (new KeysetPaginator($dataReader))
+            ->withPageSize($pageSize);
+        $this->assertTrue($paginator->isOnFirstPage());
+        $this->assertTrue($paginator->isOnLastPage());
+    }
+
+    public function onePageDataProvider() {
+        return [
+            [[], 1],
+            [[], 2],
+            [[], 3],
+
+            [array_slice($this->getDataSet(), 0, 1), 1],
+
+            [array_slice($this->getDataSet(), 0, 1), 2],
+            [array_slice($this->getDataSet(), 0, 2), 2],
+
+            [array_slice($this->getDataSet(), 0, 1), 3],
+            [array_slice($this->getDataSet(), 0, 2), 3],
+            [array_slice($this->getDataSet(), 0, 3), 3],
+
+            [array_slice($this->getDataSet(), 0, 1), 4],
+            [array_slice($this->getDataSet(), 0, 2), 4],
+            [array_slice($this->getDataSet(), 0, 3), 4],
+            [array_slice($this->getDataSet(), 0, 4), 4],
+        ];
+    }
+
     public function testReadFirstPage(): void
     {
         $sort = (new Sort(['id', 'name']))->withOrderString('id');
@@ -366,7 +403,7 @@ final class KeysetPaginatorTest extends Testcase
         $this->assertSame(1, $dataSet->getRewindCounter());
         $paginator->isOnLastPage();
         $this->assertSame(1, $dataSet->getRewindCounter());
-        foreach($paginator->read() as $void);
+        foreach ($paginator->read() as $void) ;
         $this->assertSame(1, $dataSet->getRewindCounter());
         // clear cache test
         $paginator = (new KeysetPaginator($dataReader))
@@ -379,7 +416,8 @@ final class KeysetPaginatorTest extends Testcase
         $this->assertSame(2, $dataSet->getRewindCounter());
     }
 
-    public function testTokenResults():void {
+    public function testTokenResults(): void
+    {
         $sort = (new Sort(['id']))->withOrderString('id');
         $dataReader = (new IterableDataReader($this->getDataSet()))
             ->withSort($sort);
@@ -390,7 +428,7 @@ final class KeysetPaginatorTest extends Testcase
         try {
             $paginator->getNextPageToken();
             $this->assertTrue(false);
-        } catch(\RuntimeException $e) {
+        } catch (\RuntimeException $e) {
             $this->assertTrue(true);
         }
         $this->assertNull($paginator->getPreviousPageToken());
@@ -407,7 +445,7 @@ final class KeysetPaginatorTest extends Testcase
         try {
             $paginator->getPreviousPageToken();
             $this->assertTrue(false);
-        } catch(\RuntimeException $e) {
+        } catch (\RuntimeException $e) {
             $this->assertTrue(true);
         }
         $this->assertNull($paginator->getNextPageToken());

--- a/tests/Paginator/KeysetPaginatorTest.php
+++ b/tests/Paginator/KeysetPaginatorTest.php
@@ -277,7 +277,7 @@ final class KeysetPaginatorTest extends Testcase
         $first = reset($expected);
         $last = end($expected);
         $this->assertSame((string)$last['id'], $paginator->getNextPageToken(), 'Last value fail!');
-        $this->assertSame((string)$first['id'], $paginator->getPreviousPageToken(), 'First value fail!');
+        $this->assertNull($paginator->getPreviousPageToken(), 'First value fail!');
     }
 
     public function testIsOnFirstPage(): void
@@ -298,17 +298,15 @@ final class KeysetPaginatorTest extends Testcase
         $paginator = (new KeysetPaginator($dataReader))
             ->withPageSize(2);
 
-        try {
-            $paginator->isOnLastPage();
-            $this->assertTrue(false);
-        } catch (\RuntimeException $e) {
-            $this->assertTrue(true);
-        }
         $paginator = $paginator->withNextPageToken("6");
         $this->assertSame(true, $paginator->isOnLastPage());
         $paginator = $paginator->withNextPageToken("5");
         $this->assertSame(true, $paginator->isOnLastPage());
         $paginator = $paginator->withNextPageToken("4");
+        $this->assertSame(true, $paginator->isOnLastPage());
+        $paginator = $paginator->withNextPageToken("3");
+        $this->assertSame(true, $paginator->isOnLastPage());
+        $paginator = $paginator->withNextPageToken("2");
         $this->assertSame(false, $paginator->isOnLastPage());
     }
 
@@ -403,7 +401,7 @@ final class KeysetPaginatorTest extends Testcase
         $paginator = $paginator->withPreviousPageToken("3");
         $this->assertNotNull($paginator->getNextPageToken());
         $this->assertSame("2", $paginator->getNextPageToken());
-        $this->assertNotNull($paginator->getPreviousPageToken());
+        $this->assertNull($paginator->getPreviousPageToken());
 
         $paginator = $paginator->withNextPageToken("6");
         try {
@@ -418,9 +416,9 @@ final class KeysetPaginatorTest extends Testcase
         $this->assertSame("6", $paginator->getPreviousPageToken());
         $this->assertNull($paginator->getNextPageToken());
         $paginator = $paginator->withNextPageToken("4");
+        $this->assertNull($paginator->getNextPageToken());
         $this->assertNotNull($paginator->getPreviousPageToken());
         $this->assertSame("5", $paginator->getPreviousPageToken());
-        $this->assertNotNull($paginator->getNextPageToken());
     }
 
 }


### PR DESCRIPTION
Implementation in progress. 

Paginators strongly requires repeated calls to the `read()` method, so cache is implementing. In addition, the current version relies heavily on the order of calls (`read()` must be called first), so I am correcting the resulting anomalies.

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ✔️
| Breaks BC?    | ✔️
| Tests pass?   | ✔️
| Fixed issues  | #21 

#### More tasks
- [x] more test
  - [x] `OffsetPaginator`
  - [x] `KeysetPaginator` with `isOnLastPage` and `isOnFirstPage`
  - [x] test of prevent repeated reads
- [ ] documentation