### PR TITLE
Like processor cast fix

### DIFF
--- a/src/Reader/Iterable/Processor/Like.php
+++ b/src/Reader/Iterable/Processor/Like.php
@@ -16,7 +16,7 @@ class Like implements IterableProcessorInterface, FilterProcessorInterface
     public function match(array $item, array $arguments, array $filterProcessors): bool
     {
         [$field, $value] = $arguments;
-        return stripos($item[$field], $value) !== false;
+        return stripos($item[$field], (string)$value) !== false;
     }
 
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Tests pass?   | ✔️
| Fixed issues  | -

In [stripos()](https://www.php.net/manual/en/function.stripos.php) documentation:
> If needle is not a string, it is converted to an integer and applied as the ordinal value of a character. **This behavior is deprecated as of PHP 7.3.0, and relying on it is highly discouraged. Depending on the intended behavior, the needle should either be explicitly cast to string, or an explicit call to chr() should be performed.**
