### PR TITLE
Add Default Sort

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ In sorting constructor you set which fields should be order-able and, optionally
 The order to apply is specified via `withOrder()` where you supply an array with keys correspond to field names
 and values correspond to order (`asc` or `desc`). Alternatively `withOrderString()` can be used. In this case
 ordering is represented as a single string containing comma separate field names. If name is prefixed by `-`, ordering
-direction is set to `desc`. 
+direction is set to `desc`. You can set default sort if you are not set order statement using `withDefaultOrder()`. 
 
 ### Skipping some items
 

--- a/src/Reader/Sort.php
+++ b/src/Reader/Sort.php
@@ -39,6 +39,11 @@ final class Sort
     private array $config;
 
     /**
+     * @var array this field for handling default sort if order not set
+     */
+    private array $defaultOrder = [];
+
+    /**
      * @var array field names to order by as keys, direction as values
      */
     private array $currentOrder = [];
@@ -75,13 +80,23 @@ final class Sort
     }
 
     /**
+     * @param array $defaultOrder field name for default sort if order not set
+     * @return $this
+     */
+    public function withDefaultOrder(array $defaultOrder): self
+    {
+        $new = clone $this;
+        $new->defaultOrder = $defaultOrder;
+        return $new;
+    }
+
+    /**
      * Change sorting order based on order string.
      *
      * The format must be the field name only for ascending
      * or the field name prefixed with `-` for descending.
      *
      * @param string $orderString
-     *
      * @return $this
      */
     public function withOrderString(string $orderString): self
@@ -100,7 +115,6 @@ final class Sort
 
     /**
      * @param array $order field names to order by as keys, direction as values
-     *
      * @return $this
      */
     public function withOrder(array $order): self
@@ -132,6 +146,15 @@ final class Sort
                 $criteria = array_merge($criteria, $this->config[$field][$direction]);
             }
         }
+
+        if(empty($criteria)) {
+            foreach ($this->defaultOrder as $field => $direction) {
+                if (isset($this->config[$field][$direction])) {
+                    $criteria = array_merge($criteria, $this->config[$field][$direction]);
+                }
+            }
+        }
+
         return $criteria;
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️/❌
| Breaks BC?    | ❌
| Fixed issues  | 

I think it is a good idea if we adopt default sort if property `$currentOrder` is not set. Because I have a problem if I set order with `withOrderString()`, and the order is not available in property `config`