### PR TITLE
Change Sort to have two static constructors

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,8 +177,8 @@ $data = $reader->read();
 
 ### Sorting
 
-In order to sort data in a data provider implementing `SortableDataInterface` you need to supply sort object to
-`sortFilter()` method:
+In order to sort data in a data provider implementing `SortableDataInterface` you need to supply a sort object to
+`withSort()` method:
 
 ```php
 $sorting = Sort::only([
@@ -195,11 +195,23 @@ $reader = (new MyDataReader(...))
 $data = $reader->read();
 ```
 
-In sorting constructor you set which fields should be order-able and, optionally, details on how these should be ordered.
-The order to apply is specified via `withOrder()` where you supply an array with keys correspond to field names
-and values correspond to order (`asc` or `desc`). Alternatively `withOrderString()` can be used. In this case
-ordering is represented as a single string containing comma separate field names. If name is prefixed by `-`, ordering
-direction is set to `desc`. 
+The goal of the `Sort` is to map logical fields sorting to real data set fields sorting and form a criteria for the data
+reader. Logical fields are the ones user operates with. Real fields are the ones actually present in a data set.
+Such a mapping helps when you need to sort by a single logical field that, in fact, consists of multiple fields
+in underlying the data set. For example, we provide a user with a username which consists of first name and last name
+fields in actual data set.
+
+To get a `Sort` instance, you can use either `Sort::only()` or `Sort::any()`. `Sort::only()` ignores user-specified order
+for logical fields that have no configuration. `Sort::any()` uses user-specified logical field name and order directly
+for fields that have no configuration.
+
+Either way you pass a config array that specifies which logical fields should be order-able and, optionally, details on
+how these should map to real fields order.
+
+The current order to apply is specified via `withOrder()` where you supply an array with keys corresponding to logical
+field names and values correspond to order (`asc` or `desc`). Alternatively `withOrderString()` can be used. In this case
+ordering is represented as a single string containing comma separate logical field names. If the name is prefixed by `-`,
+ordering direction is set to `desc`.
 
 ### Skipping some items
 

--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ In order to sort data in a data provider implementing `SortableDataInterface` yo
 `sortFilter()` method:
 
 ```php
-$sorting = new Sort([
+$sorting = Sort::only([
     'id',
     'name'
 ]);
@@ -279,7 +279,7 @@ Disadvantages:
 Usage is the following:
 
 ```php
-$sort = (new Sort(['id', 'name']))->withOrderString('id');
+$sort = Sort::only(['id', 'name'])->withOrderString('id');
 
 $dataReader = (new MyDataReader(...))
     ->withSort($sort);

--- a/src/Reader/Sort.php
+++ b/src/Reader/Sort.php
@@ -70,22 +70,22 @@ final class Sort
     {
         $this->modeOnly = $anyFields;
         $normalizedConfig = [];
-        foreach ($config as $fldName => $fldConfig) {
-            if (!(is_int($fldName) && is_string($fldConfig)) && !(is_string($fldName) && is_array($fldConfig))) {
+        foreach ($config as $fieldName => $fieldConfig) {
+            if (!(is_int($fieldName) && is_string($fieldConfig)) && !(is_string($fieldName) && is_array($fieldConfig))) {
                 throw new \InvalidArgumentException('Invalid config format.');
             }
 
-            if (is_string($fldConfig)) {
-                $fldName = $fldConfig;
-                $fldConfig = [];
+            if (is_string($fieldConfig)) {
+                $fieldName = $fieldConfig;
+                $fieldConfig = [];
             }
 
-            /** @psalm-var TConfig $fldConfig */
-            $normalizedConfig[$fldName] = array_merge([
-                'asc' => [$fldName => SORT_ASC],
-                'desc' => [$fldName => SORT_DESC],
+            /** @psalm-var TConfig $fieldConfig */
+            $normalizedConfig[$fieldName] = array_merge([
+                'asc' => [$fieldName => SORT_ASC],
+                'desc' => [$fieldName => SORT_DESC],
                 'default' => 'asc',
-            ], $fldConfig);
+            ], $fieldConfig);
         }
 
         /** @psalm-var TConfig $normalizedConfig */

--- a/src/Reader/Sort.php
+++ b/src/Reader/Sort.php
@@ -10,7 +10,25 @@ use function is_int;
 use function is_string;
 
 /**
- * Sort represents information relevant to sorting according to one or multiple item fields.
+ * Sort represents data sorting settings:
+ *
+ * - A config with a map of logical field => real fields along with their order. The config also contains default
+ *   order for each logical field.
+ * - Currently specified logical fields order such as field1 => asc, field2 => desc. Usually it is passed directly
+ *   from end user.
+ *
+ * Logical fields are the ones user operates with. Real fields are the ones actually present in a data set.
+ * Such a mapping helps when you need to sort by a single logical field that, in fact, consists of multiple fields
+ * in underlying the data set. For example, we provide a user with a username which consists of first name and last name
+ * fields in actual data set.
+ *
+ * Based on the settings, the class can produce a criteria to be applied to {@see SortableDataInterface}
+ * when obtaining the data i.e. a list of real fields along with their order directions.
+ *
+ * There are two modes of forming a criteria available:
+ *
+ * - {@see Sort::only()} ignores user-specified order for logical fields that have no configuration.
+ * - {@see Sort::any()} uses user-specified logical field name and order directly for fields that have no configuration.
  *
  * @template TSortFieldItem as array<string, int>
  * @template TConfigItem as array{asc: TSortFieldItem, desc: TSortFieldItem, default: string}
@@ -20,20 +38,61 @@ use function is_string;
  */
 final class Sort
 {
-    /** @psalm-var TConfig */
+    /**
+     * Logical fields config.
+     * @psalm-var TConfig
+     */
     private array $config;
 
-    private bool $modeOnly;
+    /**
+     * @var bool Whether to ignore logical fields not present in the config when forming criteria.
+     */
+    private bool $ignoreExtraFields;
 
     /**
-     * @var array Field names to order by as keys, direction as values.
+     * @var array Logical fields to order by in form of [name => direction].
      */
     private array $currentOrder = [];
 
     /**
-     * @var array $config A list of sortable fields along with their
-     * configuration.
+     * @psalm-param TUserConfig $config
+     * @param array $config Logical fields config.
+     * @param bool $ignoreExtraFields Whether to ignore logical fields not present in the config when forming criteria.
+     */
+    private function __construct(bool $ignoreExtraFields, array $config)
+    {
+        $this->ignoreExtraFields = $ignoreExtraFields;
+        $normalizedConfig = [];
+        foreach ($config as $fieldName => $fieldConfig) {
+            if (
+                !(is_int($fieldName) && is_string($fieldConfig))
+                && !(is_string($fieldName) && is_array($fieldConfig))
+            ) {
+                throw new \InvalidArgumentException('Invalid config format.');
+            }
+
+            if (is_string($fieldConfig)) {
+                $fieldName = $fieldConfig;
+                $fieldConfig = [];
+            }
+
+            /** @psalm-var TConfig $fieldConfig */
+            $normalizedConfig[$fieldName] = array_merge([
+                'asc' => [$fieldName => SORT_ASC],
+                'desc' => [$fieldName => SORT_DESC],
+                'default' => 'asc',
+            ], $fieldConfig);
+        }
+
+        /** @psalm-var TConfig $normalizedConfig */
+        $this->config = $normalizedConfig;
+    }
+
+    /**
+     * Create a sort instance that ignores current order for extra logical fields that have no configuration.
      *
+     * @psalm-param TUserConfig $config
+     * @param array $config Logical fields config.
      * ```php
      * [
      *     'age', // means will be sorted as is
@@ -64,39 +123,8 @@ final class Sort
      * - `asc` - criteria for ascending sorting.
      * - `desc` - criteria for descending sorting.
      * - `default` - default sorting. Could be either `asc` or `desc`. If not specified, `asc` is used.
-     * @psalm-var TUserConfig $config
-     */
-    private function __construct(bool $anyFields, array $config)
-    {
-        $this->modeOnly = $anyFields;
-        $normalizedConfig = [];
-        foreach ($config as $fieldName => $fieldConfig) {
-            if (
-                !(is_int($fieldName) && is_string($fieldConfig))
-                && !(is_string($fieldName) && is_array($fieldConfig))
-            ) {
-                throw new \InvalidArgumentException('Invalid config format.');
-            }
-
-            if (is_string($fieldConfig)) {
-                $fieldName = $fieldConfig;
-                $fieldConfig = [];
-            }
-
-            /** @psalm-var TConfig $fieldConfig */
-            $normalizedConfig[$fieldName] = array_merge([
-                'asc' => [$fieldName => SORT_ASC],
-                'desc' => [$fieldName => SORT_DESC],
-                'default' => 'asc',
-            ], $fieldConfig);
-        }
-
-        /** @psalm-var TConfig $normalizedConfig */
-        $this->config = $normalizedConfig;
-    }
-
-    /**
-     * @psalm-var TUserConfig $config
+     *
+     * @return self
      */
     public static function only(array $config): self
     {
@@ -104,7 +132,41 @@ final class Sort
     }
 
     /**
+     * Create a sort instance that uses logical field itself and direction provided when there is no configuration.
+     *
      * @psalm-var TUserConfig $config
+     * @param array $config Logical fields config.
+     * ```php
+     * [
+     *     'age', // means will be sorted as is
+     *     'name' => [
+     *         'asc' => ['first_name' => SORT_ASC, 'last_name' => SORT_ASC],
+     *         'desc' => ['first_name' => SORT_DESC, 'last_name' => SORT_DESC],
+     *         'default' => 'desc',
+     *     ],
+     * ]
+     * ```
+     *
+     * In the above, two fields are declared: `age` and `name`. The `age` field is
+     * a simple field which is equivalent to the following:
+     *
+     * ```php
+     * 'age' => [
+     *     'asc' => ['age' => SORT_ASC],
+     *     'desc' => ['age' => SORT_DESC],
+     *     'default' => 'asc',
+     * ]
+     * ```
+     *
+     * The name field is a virtual field name that consists of two real fields, `first_name` amd `last_name`. Virtual
+     * field name is used in order string or order array while real fields are used in final sorting criteria.
+     *
+     * Each configuration has the following options:
+     *
+     * - `asc` - criteria for ascending sorting.
+     * - `desc` - criteria for descending sorting.
+     * - `default` - default sorting. Could be either `asc` or `desc`. If not specified, `asc` is used.
+     * @return Sort
      */
     public static function any(array $config = []): self
     {
@@ -112,14 +174,15 @@ final class Sort
     }
 
     /**
-     * Change sorting order based on order string.
+     * Change current logical fields order based on order string.
      *
-     * The format must be the field name only for ascending
-     * or the field name prefixed with `-` for descending.
+     * The string consists of comma-separated field names.
+     * If the name is prefixed with `-`, field order is descending.
+     * Otherwise the order is ascending.
      *
-     * @param string $orderString
+     * @param string $orderString Logical fields order as comma-separated string.
      *
-     * @return $this
+     * @return self
      */
     public function withOrderString(string $orderString): self
     {
@@ -136,9 +199,11 @@ final class Sort
     }
 
     /**
-     * @param array $order Field names to order by as keys, direction as values.
+     * Change current logical fields order.
      *
-     * @return $this
+     * @param array $order A map with logical field names to order by as keys, direction as values.
+     *
+     * @return self
      */
     public function withOrder(array $order): self
     {
@@ -152,6 +217,15 @@ final class Sort
         return $this->currentOrder;
     }
 
+    /**
+     * Get an order string based on current logical fields order.
+     *
+     * The string consists of comma-separated field names.
+     * If the name is prefixed with `-`, field order is descending.
+     * Otherwise the order is ascending.
+     *
+     * @return string An order string.
+     */
     public function getOrderAsString(): string
     {
         $parts = [];
@@ -162,7 +236,8 @@ final class Sort
     }
 
     /**
-     * Final sorting criteria to apply.
+     * A sorting criteria to be applied to {@see SortableDataInterface}
+     * when obtaining the data i.e. a list of real fields along with their order directions.
      */
     public function getCriteria(): array
     {
@@ -174,7 +249,7 @@ final class Sort
         foreach ($order as $field => $direction) {
             $fieldExists = array_key_exists($field, $config);
             if (!$fieldExists) {
-                if ($this->modeOnly) {
+                if ($this->ignoreExtraFields) {
                     continue;
                 }
                 $criteria += [$field => $direction];

--- a/src/Reader/Sort.php
+++ b/src/Reader/Sort.php
@@ -71,7 +71,10 @@ final class Sort
         $this->modeOnly = $anyFields;
         $normalizedConfig = [];
         foreach ($config as $fieldName => $fieldConfig) {
-            if (!(is_int($fieldName) && is_string($fieldConfig)) && !(is_string($fieldName) && is_array($fieldConfig))) {
+            if (
+                !(is_int($fieldName) && is_string($fieldConfig))
+                && !(is_string($fieldName) && is_array($fieldConfig))
+            ) {
                 throw new \InvalidArgumentException('Invalid config format.');
             }
 

--- a/src/Reader/Sort.php
+++ b/src/Reader/Sort.php
@@ -30,10 +30,10 @@ use function is_string;
  * - {@see Sort::only()} ignores user-specified order for logical fields that have no configuration.
  * - {@see Sort::any()} uses user-specified logical field name and order directly for fields that have no configuration.
  *
- * @template TSortFieldItem as array<string, int>
- * @template TConfigItem as array{asc: TSortFieldItem, desc: TSortFieldItem, default: string}
- * @template TConfig as array<string, TConfigItem>
- * @template TUserConfig as array<int, string>|array<string, array<string, int|string>>
+ * @psalm-type TSortFieldItem = array<string, int>
+ * @psalm-type TConfigItem = array{asc: TSortFieldItem, desc: TSortFieldItem, default: string}
+ * @psalm-type TConfig = array<string, TConfigItem>
+ * @psalm-type TUserConfig = array<int, string>|array<string, array<string, int|string>>
  * @psalm-immutable
  */
 final class Sort
@@ -134,7 +134,7 @@ final class Sort
     /**
      * Create a sort instance that uses logical field itself and direction provided when there is no configuration.
      *
-     * @psalm-var TUserConfig $config
+     * @psalm-param TUserConfig $config
      * @param array $config Logical fields config.
      * ```php
      * [

--- a/tests/Paginator/KeysetPaginatorTest.php
+++ b/tests/Paginator/KeysetPaginatorTest.php
@@ -61,7 +61,7 @@ final class KeysetPaginatorTest extends Testcase
 
     public function testPageSizeCannotBeLessThanOne(): void
     {
-        $sort = (new Sort(['id', 'name']))->withOrderString('id');
+        $sort = Sort::only(['id', 'name'])->withOrderString('id');
         $dataReader = (new IterableDataReader($this->getDataSet()))
             ->withSort($sort);
         $paginator = new KeysetPaginator($dataReader);
@@ -81,7 +81,7 @@ final class KeysetPaginatorTest extends Testcase
 
     public function testThrowsExceptionWhenNotSorted(): void
     {
-        $sort = new Sort(['id', 'name']);
+        $sort = Sort::only(['id', 'name']);
 
         $dataReader = (new IterableDataReader($this->getDataSet()))
             ->withSort($sort);
@@ -119,7 +119,7 @@ final class KeysetPaginatorTest extends Testcase
      */
     public function testOnePage(array $dataSet, int $pageSize): void
     {
-        $sort = (new Sort(['id', 'name']))->withOrderString('id');
+        $sort = Sort::only(['id', 'name'])->withOrderString('id');
 
         $dataReader = (new IterableDataReader($dataSet))
             ->withSort($sort);
@@ -131,7 +131,7 @@ final class KeysetPaginatorTest extends Testcase
 
     public function testEmptyData(): void
     {
-        $sort = (new Sort(['id', 'name']))->withOrderString('id');
+        $sort = Sort::only(['id', 'name'])->withOrderString('id');
         $dataReader = (new IterableDataReader([]))
             ->withSort($sort);
         $paginator = (new KeysetPaginator($dataReader))
@@ -145,7 +145,7 @@ final class KeysetPaginatorTest extends Testcase
 
     public function testReadFirstPage(): void
     {
-        $sort = (new Sort(['id', 'name']))->withOrderString('id');
+        $sort = Sort::only(['id', 'name'])->withOrderString('id');
 
         $dataReader = (new IterableDataReader($this->getDataSet()))
             ->withSort($sort);
@@ -164,7 +164,7 @@ final class KeysetPaginatorTest extends Testcase
 
     public function testReadObjectsWithPublicProperties(): void
     {
-        $sort = (new Sort(['id', 'name']))->withOrderString('id');
+        $sort = Sort::only(['id', 'name'])->withOrderString('id');
         $data = [
             $this->createObjectWithPublicProperties(1, 'Codename Boris 1'),
             $this->createObjectWithPublicProperties(2, 'Codename Boris 2'),
@@ -182,7 +182,7 @@ final class KeysetPaginatorTest extends Testcase
 
     public function testReadObjectsWithGetters(): void
     {
-        $sort = (new Sort(['id', 'name']))->withOrderString('id');
+        $sort = Sort::only(['id', 'name'])->withOrderString('id');
         $data = [
             $this->createObjectWithGetters(1, 'Codename Boris 1'),
             $this->createObjectWithGetters(2, 'Codename Boris 2'),
@@ -200,7 +200,7 @@ final class KeysetPaginatorTest extends Testcase
 
     public function testReadSecondPage(): void
     {
-        $sort = (new Sort(['id', 'name']))->withOrderString('id');
+        $sort = Sort::only(['id', 'name'])->withOrderString('id');
 
         $dataReader = (new IterableDataReader($this->getDataSet()))
             ->withSort($sort);
@@ -218,7 +218,7 @@ final class KeysetPaginatorTest extends Testcase
 
     public function testReadSecondPageOrderedByName(): void
     {
-        $sort = (new Sort(['id', 'name']))->withOrderString('name');
+        $sort = Sort::only(['id', 'name'])->withOrderString('name');
 
         $dataReader = (new IterableDataReader($this->getDataSet()))
             ->withSort($sort);
@@ -236,7 +236,7 @@ final class KeysetPaginatorTest extends Testcase
 
     public function testBackwardPagination(): void
     {
-        $sort = (new Sort(['id', 'name']))->withOrderString('id');
+        $sort = Sort::only(['id', 'name'])->withOrderString('id');
 
         $dataReader = (new IterableDataReader($this->getDataSet()))
             ->withSort($sort);
@@ -257,7 +257,7 @@ final class KeysetPaginatorTest extends Testcase
 
     public function testForwardAndBackwardPagination(): void
     {
-        $sort = (new Sort(['id', 'name']))->withOrderString('id');
+        $sort = Sort::only(['id', 'name'])->withOrderString('id');
 
         $dataReader = (new IterableDataReader($this->getDataSet()))
             ->withSort($sort);
@@ -291,7 +291,7 @@ final class KeysetPaginatorTest extends Testcase
 
     public function testIsOnFirstPage(): void
     {
-        $sort = (new Sort(['id']))->withOrderString('id');
+        $sort = Sort::only(['id'])->withOrderString('id');
         $dataReader = (new IterableDataReader($this->getDataSet()))
             ->withSort($sort);
         $paginator = (new KeysetPaginator($dataReader))
@@ -302,7 +302,7 @@ final class KeysetPaginatorTest extends Testcase
 
     public function testIsOnLastPage(): void
     {
-        $sort = (new Sort(['id']))->withOrderString('id');
+        $sort = Sort::only(['id'])->withOrderString('id');
         $dataReader = (new IterableDataReader($this->getDataSet()))
             ->withSort($sort);
         $paginator = (new KeysetPaginator($dataReader))
@@ -323,7 +323,7 @@ final class KeysetPaginatorTest extends Testcase
 
     public function testCurrentPageSize(): void
     {
-        $sort = (new Sort(['id']))->withOrderString('id');
+        $sort = Sort::only(['id'])->withOrderString('id');
         $dataReader = (new IterableDataReader($this->getDataSet()))
             ->withSort($sort);
         $paginator = (new KeysetPaginator($dataReader))
@@ -346,7 +346,7 @@ final class KeysetPaginatorTest extends Testcase
 
     public function testReadCache(): void
     {
-        $sort = (new Sort(['id']))->withOrderString('id');
+        $sort = Sort::only(['id'])->withOrderString('id');
         $dataSet = new class($this->getDataSet()) extends \ArrayIterator {
             private int $rewindCounter = 0;
 
@@ -392,7 +392,7 @@ final class KeysetPaginatorTest extends Testcase
 
     public function testTokenResults(): void
     {
-        $sort = (new Sort(['id']))->withOrderString('id');
+        $sort = Sort::only(['id'])->withOrderString('id');
         $dataReader = (new IterableDataReader($this->getDataSet()))
             ->withSort($sort);
         $paginator = (new KeysetPaginator($dataReader))
@@ -435,7 +435,7 @@ final class KeysetPaginatorTest extends Testcase
 
     public function testDefaultPageSize(): void
     {
-        $sort = (new Sort(['id']))->withOrderString('id');
+        $sort = Sort::only(['id'])->withOrderString('id');
         $dataReader = (new IterableDataReader($this->getDataSet()))->withSort($sort);
         $paginator = new KeysetPaginator($dataReader);
         $this->assertSame(10, $paginator->getPageSize());
@@ -444,7 +444,7 @@ final class KeysetPaginatorTest extends Testcase
 
     public function testCustomPageSize(): void
     {
-        $sort = (new Sort(['id']))->withOrderString('id');
+        $sort = Sort::only(['id'])->withOrderString('id');
         $dataReader = (new IterableDataReader($this->getDataSet()))->withSort($sort);
         $paginator = (new KeysetPaginator($dataReader))->withPageSize(2);
         $this->assertSame(2, $paginator->getPageSize());
@@ -518,7 +518,7 @@ final class KeysetPaginatorTest extends Testcase
 
             public function getSort(): ?Sort
             {
-                return new Sort([]);
+                return Sort::only([]);
             }
         };
     }

--- a/tests/Reader/FilterProcessorTest.php
+++ b/tests/Reader/FilterProcessorTest.php
@@ -48,7 +48,7 @@ class FilterProcessorTest extends TestCase
 
     public function testCustomEquals(): void
     {
-        $sort = (new Sort(['id', 'name']))->withOrderString('id');
+        $sort = Sort::only(['id', 'name'])->withOrderString('id');
 
         $dataReader = (new IterableDataReader($this->getDataSet()))
             ->withSort($sort)

--- a/tests/Reader/IterableDataReaderTest.php
+++ b/tests/Reader/IterableDataReaderTest.php
@@ -111,7 +111,7 @@ final class IterableDataReaderTest extends TestCase
 
     public function testSorting(): void
     {
-        $sorting = new Sort([
+        $sorting = Sort::only([
             'id',
             'name',
         ]);
@@ -143,7 +143,7 @@ final class IterableDataReaderTest extends TestCase
 
     public function testReadOneWithSortingAndOffset(): void
     {
-        $sorting = (new Sort(['id', 'name']))->withOrder(['name' => 'asc']);
+        $sorting = Sort::only(['id', 'name'])->withOrder(['name' => 'asc']);
 
         $data = $this->getDataSet();
         $reader = (new IterableDataReader($data))
@@ -358,7 +358,7 @@ final class IterableDataReaderTest extends TestCase
     {
         $readerMin = (new IterableDataReader($this->getDataSet()))
             ->withSort(
-                (new Sort(['id']))->withOrder(['id' => 'asc'])
+                Sort::only(['id'])->withOrder(['id' => 'asc'])
             )
             ->withLimit(1);
         $min = $readerMin->read()[0]['id'];
@@ -366,7 +366,7 @@ final class IterableDataReaderTest extends TestCase
 
         $readerMax = (new IterableDataReader($this->getDataSet()))
             ->withSort(
-                (new Sort(['id']))->withOrder(['id' => 'desc'])
+                Sort::only(['id'])->withOrder(['id' => 'desc'])
             )
             ->withLimit(1);
         $max = $readerMax->read()[0]['id'];
@@ -388,7 +388,7 @@ final class IterableDataReaderTest extends TestCase
     public function testIteratorIteratorAsDataSet(): void
     {
         $reader = new IterableDataReader(new \ArrayIterator($this->getDataSet()));
-        $sorting = new Sort([
+        $sorting = Sort::only([
             'id',
             'name',
         ]);
@@ -404,7 +404,7 @@ final class IterableDataReaderTest extends TestCase
     public function testGeneratorAsDataSet(): void
     {
         $reader = new IterableDataReader($this->getDataSetAsGenerator());
-        $sorting = new Sort([
+        $sorting = Sort::only([
             'id',
             'name',
         ]);


### PR DESCRIPTION
Add `Sort::any()` and `Sort::only()` methods instead of constuctor

| Q             | A
| ------------- | ---
| Breaks BC?    | ✔️
| Fixed issues  | decide #67

todo:

- [x] Fix documentation
- [x] Fix other repositories
  - [x] app-api https://github.com/yiisoft/app-api/pull/38
  - [x] yii-cycle https://github.com/yiisoft/yii-cycle/pull/93
  - [x] yii-dataview https://github.com/yiisoft/yii-dataview/pull/42
  - [x] yii-demo https://github.com/yiisoft/yii-demo/pull/231