### PR TITLE
Rename `PaginatorInterface` method `getCurrentPageSize()` to `getCountItems()`

### DIFF
--- a/src/Paginator/KeysetPaginator.php
+++ b/src/Paginator/KeysetPaginator.php
@@ -188,7 +188,7 @@ final class KeysetPaginator implements PaginatorInterface
         return $this->pageSize;
     }
 
-    public function getCurrentPageSize(): int
+    public function getCountItems(): int
     {
         $this->initialize();
         return count($this->readCache);

--- a/src/Paginator/OffsetPaginator.php
+++ b/src/Paginator/OffsetPaginator.php
@@ -115,7 +115,7 @@ final class OffsetPaginator implements PaginatorInterface
         return $this->currentPage;
     }
 
-    public function getCurrentPageSize(): int
+    public function getCountItems(): int
     {
         $pages = $this->getInternalTotalPages();
 

--- a/src/Paginator/PaginatorInterface.php
+++ b/src/Paginator/PaginatorInterface.php
@@ -26,7 +26,7 @@ interface PaginatorInterface
 
     public function getPageSize(): int;
 
-    public function getCurrentPageSize(): int;
+    public function getCountItems(): int;
 
     /**
      * @return Sort|null Current sort object or null if no sorting is used.

--- a/tests/Paginator/KeysetPaginatorTest.php
+++ b/tests/Paginator/KeysetPaginatorTest.php
@@ -362,25 +362,25 @@ final class KeysetPaginatorTest extends Testcase
         $sort = Sort::only(['id'])->withOrderString('id');
         $dataReader = (new IterableDataReader($this->getDataSet()))->withSort($sort);
         $paginator = (new KeysetPaginator($dataReader))->withPageSize(2);
-        $this->assertSame(2, $paginator->getCurrentPageSize());
+        $this->assertSame(2, $paginator->getCountItems());
 
         $paginator = $paginator->withPreviousPageToken('1');
-        $this->assertSame(0, $paginator->getCurrentPageSize());
+        $this->assertSame(0, $paginator->getCountItems());
 
         $paginator = $paginator->withPreviousPageToken('2');
-        $this->assertSame(1, $paginator->getCurrentPageSize());
+        $this->assertSame(1, $paginator->getCountItems());
 
         $paginator = $paginator->withPreviousPageToken('3');
-        $this->assertSame(2, $paginator->getCurrentPageSize());
+        $this->assertSame(2, $paginator->getCountItems());
 
         $paginator = $paginator->withNextPageToken('6');
-        $this->assertSame(0, $paginator->getCurrentPageSize());
+        $this->assertSame(0, $paginator->getCountItems());
 
         $paginator = $paginator->withNextPageToken('5');
-        $this->assertSame(1, $paginator->getCurrentPageSize());
+        $this->assertSame(1, $paginator->getCountItems());
 
         $paginator = $paginator->withNextPageToken('4');
-        $this->assertSame(2, $paginator->getCurrentPageSize());
+        $this->assertSame(2, $paginator->getCountItems());
     }
 
     public function testReadCache(): void
@@ -405,10 +405,10 @@ final class KeysetPaginatorTest extends Testcase
         // not use datase test
         $this->assertSame(0, $dataSet->getRewindCounter());
         // first use dataset test
-        $paginator->getCurrentPageSize();
+        $paginator->getCountItems();
         $this->assertSame(1, $dataSet->getRewindCounter());
         // repeated use dataset test
-        $paginator->getCurrentPageSize();
+        $paginator->getCountItems();
         $this->assertSame(1, $dataSet->getRewindCounter());
 
         $paginator->isOnFirstPage();
@@ -425,9 +425,9 @@ final class KeysetPaginatorTest extends Testcase
             ->withPageSize(3);
         $this->assertSame(1, $dataSet->getRewindCounter());
         // recreate cache
-        $paginator->getCurrentPageSize();
+        $paginator->getCountItems();
         $this->assertSame(2, $dataSet->getRewindCounter());
-        $paginator->getCurrentPageSize();
+        $paginator->getCountItems();
         $this->assertSame(2, $dataSet->getRewindCounter());
     }
 

--- a/tests/Paginator/OffsetPaginatorTest.php
+++ b/tests/Paginator/OffsetPaginatorTest.php
@@ -324,15 +324,15 @@ final class OffsetPaginatorTest extends TestCase
         $paginator->isOnLastPage();
     }
 
-    public function testGetCurrentPageSizeFirstFullPage(): void
+    public function testGetCountItemsFirstFullPage(): void
     {
         $dataReader = new IterableDataReader(self::DEFAULT_DATASET);
         $paginator = (new OffsetPaginator($dataReader))->withPageSize(3);
 
-        $this->assertSame(3, $paginator->getCurrentPageSize());
+        $this->assertSame(3, $paginator->getCountItems());
     }
 
-    public function testGetCurrentPageSizeLastPage(): void
+    public function testGetCountItemsLastPage(): void
     {
         $dataReader = new IterableDataReader(self::DEFAULT_DATASET);
         $paginator = (new OffsetPaginator($dataReader))
@@ -340,16 +340,16 @@ final class OffsetPaginatorTest extends TestCase
             ->withCurrentPage(2)
         ;
 
-        $this->assertSame(2, $paginator->getCurrentPageSize());
+        $this->assertSame(2, $paginator->getCountItems());
         $this->assertSame(5, $paginator->getTotalItems());
     }
 
-    public function testGetCurrentPageSizeFirstNotFullPage(): void
+    public function testGetCountItemsFirstNotFullPage(): void
     {
         $dataReader = new IterableDataReader(self::DEFAULT_DATASET);
         $paginator = (new OffsetPaginator($dataReader))->withPageSize(30);
 
-        $this->assertSame(5, $paginator->getCurrentPageSize());
+        $this->assertSame(5, $paginator->getCountItems());
         $this->assertSame(5, $paginator->getTotalItems());
     }
 
@@ -358,7 +358,7 @@ final class OffsetPaginatorTest extends TestCase
         $dataReader = new IterableDataReader(self::DEFAULT_DATASET);
         $paginator = (new OffsetPaginator($dataReader))->withCurrentPage(5);
 
-        $this->assertSame(5, $paginator->getCurrentPageSize());
+        $this->assertSame(5, $paginator->getCountItems());
         $this->assertSame(5, $paginator->getTotalItems());
     }
 
@@ -374,7 +374,7 @@ final class OffsetPaginatorTest extends TestCase
         $this->expectException(PaginatorException::class);
         $this->expectExceptionMessage('Page not found.');
 
-        $paginator->getCurrentPageSize();
+        $paginator->getCountItems();
     }
 
     public function testEmptyDataSet(): void
@@ -384,7 +384,7 @@ final class OffsetPaginatorTest extends TestCase
 
         $this->assertSame(0, $paginator->getTotalItems());
         $this->assertSame(0, $paginator->getTotalPages());
-        $this->assertSame(0, $paginator->getCurrentPageSize());
+        $this->assertSame(0, $paginator->getCountItems());
         $this->assertSame(1, $paginator->getCurrentPage());
         $this->assertTrue($paginator->isOnFirstPage());
         $this->assertTrue($paginator->isOnLastPage());


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ✔️
| Fixed issues  | -