### PR TITLE
Fix psalm errors + Improve type hints + Add support of object arrays to `IterableDataReader`

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -28,7 +28,7 @@ jobs:
       os: >-
         ['ubuntu-latest']
       php: >-
-        ['8.0', '8.1']
+        ['8.1']
   psalm-php80:
     uses: yiisoft/actions/.github/workflows/psalm.yml@master
     with:

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -29,3 +29,11 @@ jobs:
         ['ubuntu-latest']
       php: >-
         ['8.0', '8.1']
+  psalm-php80:
+    uses: yiisoft/actions/.github/workflows/psalm.yml@master
+    with:
+      psalm-config: psalm-php80.xml
+      os: >-
+        ['ubuntu-latest']
+      php: >-
+        ['8.0']

--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
         "rector/rector": "^0.15.0",
         "roave/infection-static-analysis-plugin": "^1.25",
         "spatie/phpunit-watcher": "^1.23",
-        "vimeo/psalm": "^4.26|^5.0"
+        "vimeo/psalm": "^4.26|^5.4"
     },
     "autoload": {
         "psr-4": {

--- a/psalm-php80.xml
+++ b/psalm-php80.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+<psalm
+    errorLevel="1"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns="https://getpsalm.org/schema/config"
+    xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"
+>
+    <projectFiles>
+        <directory name="src" />
+        <ignoreFiles>
+            <directory name="vendor"/>
+            <file name="src/Paginator/KeysetPaginator.php"/>
+            <file name="src/Paginator/OffsetPaginator.php"/>
+        </ignoreFiles>
+    </projectFiles>
+</psalm>

--- a/src/Paginator/KeysetPaginator.php
+++ b/src/Paginator/KeysetPaginator.php
@@ -36,7 +36,7 @@ use function sprintf;
  * @link https://use-the-index-luke.com/no-offset
  *
  * @template TKey as array-key
- * @template TValue
+ * @template TValue as array|object
  *
  * @implements PaginatorInterface<TKey, TValue>
  */
@@ -90,14 +90,13 @@ final class KeysetPaginator implements PaginatorInterface
             ));
         }
 
-        if ($dataReader->getSort() === null) {
+        $sort = $dataReader->getSort();
+
+        if ($sort === null) {
             throw new RuntimeException('Data sorting should be configured to work with keyset pagination.');
         }
 
-        /** @psalm-suppress PossiblyNullReference */
-        if ($dataReader
-                ->getSort()
-                ->getOrder() === []) {
+        if (empty($sort->getOrder())) {
             throw new RuntimeException('Data should be always sorted to work with keyset pagination.');
         }
 
@@ -144,8 +143,6 @@ final class KeysetPaginator implements PaginatorInterface
      * Reads items of the page.
      *
      * This method uses the read cache to prevent duplicate reads from the data source. See more {@see resetInternal()}.
-     *
-     * @psalm-suppress MixedMethodCall
      */
     public function read(): iterable
     {
@@ -289,10 +286,7 @@ final class KeysetPaginator implements PaginatorInterface
         return !empty($dataReader->withFilter($reverseFilter)->withLimit(1)->read());
     }
 
-    /**
-     * @return mixed
-     */
-    private function getValueFromItem(mixed $item, string $field)
+    private function getValueFromItem(array|object $item, string $field): mixed
     {
         $methodName = 'get' . (new Inflector())->toPascalCase($field);
 
@@ -300,7 +294,6 @@ final class KeysetPaginator implements PaginatorInterface
             return $item->$methodName();
         }
 
-        /** @psalm-suppress MixedArgument */
         return ArrayHelper::getValue($item, $field);
     }
 

--- a/src/Paginator/OffsetPaginator.php
+++ b/src/Paginator/OffsetPaginator.php
@@ -17,8 +17,6 @@ use function max;
 use function sprintf;
 
 /**
- * @psalm-template DataReaderType = ReadableDataInterface<TKey, TValue>&OffsetableDataInterface&CountableDataInterface
- *
  * @template TKey as array-key
  * @template TValue
  *
@@ -30,17 +28,18 @@ final class OffsetPaginator implements PaginatorInterface
     private int $pageSize = self::DEFAULT_PAGE_SIZE;
 
     /**
-     * @psalm-var DataReaderType
+     * @psalm-var ReadableDataInterface<TKey, TValue>&OffsetableDataInterface&CountableDataInterface
      */
     private ReadableDataInterface $dataReader;
 
     /**
-     * @psalm-var DataReaderType|null
+     * @psalm-var ReadableDataInterface<TKey, TValue>&OffsetableDataInterface&CountableDataInterface|null
      */
     private ?ReadableDataInterface $cachedReader = null;
 
     /**
-     * @psalm-param DataReaderType $dataReader
+     * @psalm-param ReadableDataInterface<TKey, TValue>&OffsetableDataInterface&CountableDataInterface $dataReader
+     * @psalm-suppress DocblockTypeContradiction
      */
     public function __construct(ReadableDataInterface $dataReader)
     {
@@ -141,7 +140,6 @@ final class OffsetPaginator implements PaginatorInterface
 
     public function getTotalItems(): int
     {
-        /** @psalm-var CountableDataInterface $this->dataReader */
         return $this->dataReader->count();
     }
 
@@ -156,7 +154,7 @@ final class OffsetPaginator implements PaginatorInterface
     }
 
     /**
-     * @psalm-return Generator<TKey, TValue, mixed, void>
+     * @psalm-return Generator<TKey, TValue, mixed, null>
      * @psalm-suppress MixedAssignment, MixedMethodCall, MixedReturnTypeCoercion
      */
     public function read(): iterable
@@ -173,6 +171,7 @@ final class OffsetPaginator implements PaginatorInterface
         $this->cachedReader = $this->dataReader
             ->withLimit($this->pageSize)
             ->withOffset($this->getOffset());
+
         yield from $this->cachedReader->read();
     }
 

--- a/src/Paginator/OffsetPaginator.php
+++ b/src/Paginator/OffsetPaginator.php
@@ -155,7 +155,6 @@ final class OffsetPaginator implements PaginatorInterface
 
     /**
      * @psalm-return Generator<TKey, TValue, mixed, null>
-     * @psalm-suppress MixedAssignment, MixedMethodCall, MixedReturnTypeCoercion
      */
     public function read(): iterable
     {

--- a/src/Paginator/OffsetPaginator.php
+++ b/src/Paginator/OffsetPaginator.php
@@ -18,7 +18,7 @@ use function sprintf;
 
 /**
  * @template TKey as array-key
- * @template TValue
+ * @template TValue as array|object
  *
  * @implements PaginatorInterface<TKey, TValue>
  */

--- a/src/Paginator/PaginatorInterface.php
+++ b/src/Paginator/PaginatorInterface.php
@@ -8,7 +8,7 @@ use Yiisoft\Data\Reader\Sort;
 
 /**
  * @template TKey as array-key
- * @template TValue
+ * @template TValue as array|object
  */
 interface PaginatorInterface
 {

--- a/src/Reader/DataReaderInterface.php
+++ b/src/Reader/DataReaderInterface.php
@@ -8,7 +8,7 @@ use IteratorAggregate;
 
 /**
  * @template TKey as array-key
- * @template TValue
+ * @template TValue as array|object
  *
  * @extends ReadableDataInterface<TKey, TValue>
  * @extends IteratorAggregate<TKey, TValue>

--- a/src/Reader/Filter/GroupFilter.php
+++ b/src/Reader/Filter/GroupFilter.php
@@ -56,6 +56,8 @@ abstract class GroupFilter implements FilterInterface
      * @param array[]|FilterInterface[] $filtersArray
      *
      * @return static
+     *
+     * @psalm-suppress DocblockTypeContradiction
      */
     public function withFiltersArray(array $filtersArray): self
     {
@@ -64,7 +66,6 @@ abstract class GroupFilter implements FilterInterface
                 continue;
             }
 
-            /** @psalm-suppress DocblockTypeContradiction */
             if (!is_array($filter)) {
                 throw new InvalidArgumentException(sprintf('Invalid filter on "%s" key.', $key));
             }

--- a/src/Reader/FilterableDataInterface.php
+++ b/src/Reader/FilterableDataInterface.php
@@ -9,7 +9,7 @@ use Yiisoft\Data\Reader\Filter\FilterProcessorInterface;
 
 interface FilterableDataInterface
 {
-    public function withFilter(FilterInterface $filter): self;
+    public function withFilter(FilterInterface $filter): static;
 
-    public function withFilterProcessors(FilterProcessorInterface ...$filterProcessors): self;
+    public function withFilterProcessors(FilterProcessorInterface ...$filterProcessors): static;
 }

--- a/src/Reader/Iterable/IterableDataReader.php
+++ b/src/Reader/Iterable/IterableDataReader.php
@@ -181,7 +181,7 @@ class IterableDataReader implements DataReaderInterface
             ->current();
     }
 
-    protected function matchFilter(array $item, array $filter): bool
+    protected function matchFilter(array|object $item, array $filter): bool
     {
         $operation = array_shift($filter);
         $arguments = $filter;

--- a/src/Reader/Iterable/IterableDataReader.php
+++ b/src/Reader/Iterable/IterableDataReader.php
@@ -227,11 +227,11 @@ class IterableDataReader implements DataReaderInterface
             $items = $this->iterableToArray($items);
             uasort(
                 $items,
-                static function (mixed $itemA, mixed $itemB) use ($criteria) {
+                static function (array|object $itemA, array|object $itemB) use ($criteria) {
                     foreach ($criteria as $key => $order) {
-                        /** @psalm-suppress MixedArgument, MixedAssignment */
+                        /** @var mixed */
                         $valueA = ArrayHelper::getValue($itemA, $key);
-                        /** @psalm-suppress MixedArgument, MixedAssignment */
+                        /** @var mixed */
                         $valueB = ArrayHelper::getValue($itemB, $key);
 
                         if ($valueB === $valueA) {

--- a/src/Reader/Iterable/IterableDataReader.php
+++ b/src/Reader/Iterable/IterableDataReader.php
@@ -77,7 +77,7 @@ class IterableDataReader implements DataReaderInterface
         )->filterProcessors;
     }
 
-    public function withFilterProcessors(FilterProcessorInterface ...$filterProcessors): self
+    public function withFilterProcessors(FilterProcessorInterface ...$filterProcessors): static
     {
         $new = clone $this;
         $processors = [];
@@ -92,14 +92,14 @@ class IterableDataReader implements DataReaderInterface
         return $new;
     }
 
-    public function withFilter(?FilterInterface $filter): self
+    public function withFilter(?FilterInterface $filter): static
     {
         $new = clone $this;
         $new->filter = $filter;
         return $new;
     }
 
-    public function withLimit(int $limit): self
+    public function withLimit(int $limit): static
     {
         if ($limit < 0) {
             throw new InvalidArgumentException('The limit must not be less than 0.');
@@ -110,14 +110,14 @@ class IterableDataReader implements DataReaderInterface
         return $new;
     }
 
-    public function withOffset(int $offset): self
+    public function withOffset(int $offset): static
     {
         $new = clone $this;
         $new->offset = $offset;
         return $new;
     }
 
-    public function withSort(?Sort $sort): self
+    public function withSort(?Sort $sort): static
     {
         $new = clone $this;
         $new->sort = $sort;

--- a/src/Reader/Iterable/IterableDataReader.php
+++ b/src/Reader/Iterable/IterableDataReader.php
@@ -39,7 +39,7 @@ use function uasort;
 
 /**
  * @template TKey as array-key
- * @template TValue
+ * @template TValue as array|object
  *
  * @implements DataReaderInterface<TKey, TValue>
  */
@@ -125,7 +125,7 @@ class IterableDataReader implements DataReaderInterface
     }
 
     /**
-     * @psalm-return Generator<TValue>
+     * @psalm-return Generator<array-key, TValue, mixed, void>
      */
     public function getIterator(): Generator
     {
@@ -142,6 +142,9 @@ class IterableDataReader implements DataReaderInterface
         return count($this->read());
     }
 
+    /**
+     * @psalm-return array<TKey, TValue>
+     */
     public function read(): array
     {
         $data = [];
@@ -149,10 +152,6 @@ class IterableDataReader implements DataReaderInterface
         $filter = $this->filter?->toArray();
         $sortedData = $this->sort === null ? $this->data : $this->sortItems($this->data, $this->sort);
 
-        /**
-         * @var int|string $key
-         * @var array $item
-         */
         foreach ($sortedData as $key => $item) {
             // Do not return more than limit items.
             if ($this->limit > 0 && count($data) === $this->limit) {
@@ -174,10 +173,7 @@ class IterableDataReader implements DataReaderInterface
         return $data;
     }
 
-    /**
-     * @return mixed
-     */
-    public function readOne()
+    public function readOne(): array|object|null
     {
         return $this
             ->withLimit(1)
@@ -218,7 +214,10 @@ class IterableDataReader implements DataReaderInterface
      * @param iterable $items The items to be sorted.
      * @param Sort $sort The sort definition.
      *
-     * @return iterable The sorted items.
+     * @return array The sorted items.
+     *
+     * @psalm-param iterable<TKey, TValue> $items
+     * @psalm-return iterable<TKey, TValue>
      */
     private function sortItems(iterable $items, Sort $sort): iterable
     {
@@ -228,10 +227,6 @@ class IterableDataReader implements DataReaderInterface
             $items = $this->iterableToArray($items);
             uasort(
                 $items,
-                /**
-                 * @param mixed $itemA
-                 * @param mixed $itemB
-                 */
                 static function (mixed $itemA, mixed $itemB) use ($criteria) {
                     foreach ($criteria as $key => $order) {
                         /** @psalm-suppress MixedArgument, MixedAssignment */
@@ -254,6 +249,11 @@ class IterableDataReader implements DataReaderInterface
         return $items;
     }
 
+    /**
+     * @param iterable<TKey, TValue> $iterable
+     *
+     * @return array<TKey, TValue>
+     */
     private function iterableToArray(iterable $iterable): array
     {
         return $iterable instanceof Traversable ? iterator_to_array($iterable, true) : $iterable;

--- a/src/Reader/Iterable/Processor/Between.php
+++ b/src/Reader/Iterable/Processor/Between.php
@@ -6,10 +6,10 @@ namespace Yiisoft\Data\Reader\Iterable\Processor;
 
 use DateTimeInterface;
 use InvalidArgumentException;
+use Yiisoft\Arrays\ArrayHelper;
 use Yiisoft\Data\Reader\Filter\FilterProcessorInterface;
 use Yiisoft\Data\Reader\FilterDataValidationHelper;
 
-use function array_key_exists;
 use function count;
 
 final class Between implements IterableProcessorInterface, FilterProcessorInterface
@@ -19,7 +19,7 @@ final class Between implements IterableProcessorInterface, FilterProcessorInterf
         return \Yiisoft\Data\Reader\Filter\Between::getOperator();
     }
 
-    public function match(array $item, array $arguments, array $filterProcessors): bool
+    public function match(array|object $item, array $arguments, array $filterProcessors): bool
     {
         if (count($arguments) !== 3) {
             throw new InvalidArgumentException('$arguments should contain exactly three elements.');
@@ -29,17 +29,15 @@ final class Between implements IterableProcessorInterface, FilterProcessorInterf
         [$field, $firstValue, $secondValue] = $arguments;
         FilterDataValidationHelper::assertFieldIsString($field);
 
-        if (!array_key_exists($field, $item)) {
-            return false;
-        }
+        $value = ArrayHelper::getValue($item, $field);
 
-        if (!$item[$field] instanceof DateTimeInterface) {
-            return $item[$field] >= $firstValue && $item[$field] <= $secondValue;
+        if (!$value instanceof DateTimeInterface) {
+            return $value >= $firstValue && $value <= $secondValue;
         }
 
         return $firstValue instanceof DateTimeInterface
             && $secondValue instanceof DateTimeInterface
-            && $item[$field]->getTimestamp() >= $firstValue->getTimestamp()
-            && $item[$field]->getTimestamp() <= $secondValue->getTimestamp();
+            && $value->getTimestamp() >= $firstValue->getTimestamp()
+            && $value->getTimestamp() <= $secondValue->getTimestamp();
     }
 }

--- a/src/Reader/Iterable/Processor/CompareProcessor.php
+++ b/src/Reader/Iterable/Processor/CompareProcessor.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Yiisoft\Data\Reader\Iterable\Processor;
 
 use InvalidArgumentException;
+use Yiisoft\Arrays\ArrayHelper;
 use Yiisoft\Data\Reader\Filter\FilterProcessorInterface;
 use Yiisoft\Data\Reader\FilterDataValidationHelper;
 
@@ -19,7 +20,7 @@ abstract class CompareProcessor implements IterableProcessorInterface, FilterPro
      */
     abstract protected function compare($itemValue, $argumentValue): bool;
 
-    public function match(array $item, array $arguments, array $filterProcessors): bool
+    public function match(array|object $item, array $arguments, array $filterProcessors): bool
     {
         if (count($arguments) !== 2) {
             throw new InvalidArgumentException('$arguments should contain exactly two elements.');
@@ -29,6 +30,6 @@ abstract class CompareProcessor implements IterableProcessorInterface, FilterPro
         FilterDataValidationHelper::assertFieldIsString($field);
 
         /** @var string $field */
-        return array_key_exists($field, $item) && $this->compare($item[$field], $value);
+        return $this->compare(ArrayHelper::getValue($item, $field), $value);
     }
 }

--- a/src/Reader/Iterable/Processor/EqualsEmpty.php
+++ b/src/Reader/Iterable/Processor/EqualsEmpty.php
@@ -17,7 +17,7 @@ final class EqualsEmpty implements IterableProcessorInterface, FilterProcessorIn
         return \Yiisoft\Data\Reader\Filter\EqualsEmpty::getOperator();
     }
 
-    public function match(array $item, array $arguments, array $filterProcessors): bool
+    public function match(array|object $item, array $arguments, array $filterProcessors): bool
     {
         if (count($arguments) !== 1) {
             throw new InvalidArgumentException('$arguments should contain exactly one element.');

--- a/src/Reader/Iterable/Processor/EqualsNull.php
+++ b/src/Reader/Iterable/Processor/EqualsNull.php
@@ -5,10 +5,10 @@ declare(strict_types=1);
 namespace Yiisoft\Data\Reader\Iterable\Processor;
 
 use InvalidArgumentException;
+use Yiisoft\Arrays\ArrayHelper;
 use Yiisoft\Data\Reader\Filter\FilterProcessorInterface;
 use Yiisoft\Data\Reader\FilterDataValidationHelper;
 
-use function array_key_exists;
 use function count;
 
 final class EqualsNull implements IterableProcessorInterface, FilterProcessorInterface
@@ -18,7 +18,7 @@ final class EqualsNull implements IterableProcessorInterface, FilterProcessorInt
         return \Yiisoft\Data\Reader\Filter\EqualsNull::getOperator();
     }
 
-    public function match(array $item, array $arguments, array $filterProcessors): bool
+    public function match(array|object $item, array $arguments, array $filterProcessors): bool
     {
         if (count($arguments) !== 1) {
             throw new InvalidArgumentException('$arguments should contain exactly one element.');
@@ -28,6 +28,6 @@ final class EqualsNull implements IterableProcessorInterface, FilterProcessorInt
         FilterDataValidationHelper::assertFieldIsString($field);
 
         /** @var string $field */
-        return array_key_exists($field, $item) && $item[$field] === null;
+        return ArrayHelper::getValue($item, $field) === null;
     }
 }

--- a/src/Reader/Iterable/Processor/GroupProcessor.php
+++ b/src/Reader/Iterable/Processor/GroupProcessor.php
@@ -18,7 +18,7 @@ abstract class GroupProcessor implements IterableProcessorInterface, FilterProce
 {
     abstract protected function checkResults(array $results): bool;
 
-    public function match(array $item, array $arguments, array $filterProcessors): bool
+    public function match(array|object $item, array $arguments, array $filterProcessors): bool
     {
         if (count($arguments) !== 1) {
             throw new InvalidArgumentException('$arguments should contain exactly one element.');

--- a/src/Reader/Iterable/Processor/IterableProcessorInterface.php
+++ b/src/Reader/Iterable/Processor/IterableProcessorInterface.php
@@ -6,5 +6,5 @@ namespace Yiisoft\Data\Reader\Iterable\Processor;
 
 interface IterableProcessorInterface
 {
-    public function match(array $item, array $arguments, array $filterProcessors): bool;
+    public function match(array|object $item, array $arguments, array $filterProcessors): bool;
 }

--- a/src/Reader/Iterable/Processor/Not.php
+++ b/src/Reader/Iterable/Processor/Not.php
@@ -21,7 +21,7 @@ final class Not implements IterableProcessorInterface, FilterProcessorInterface
         return \Yiisoft\Data\Reader\Filter\Not::getOperator();
     }
 
-    public function match(array $item, array $arguments, array $filterProcessors): bool
+    public function match(array|object $item, array $arguments, array $filterProcessors): bool
     {
         if (count($arguments) !== 1) {
             throw new InvalidArgumentException('$arguments should contain exactly one element.');

--- a/src/Reader/OffsetableDataInterface.php
+++ b/src/Reader/OffsetableDataInterface.php
@@ -6,5 +6,8 @@ namespace Yiisoft\Data\Reader;
 
 interface OffsetableDataInterface
 {
+    /**
+     * @psalm-return static
+     */
     public function withOffset(int $offset): static;
 }

--- a/src/Reader/OffsetableDataInterface.php
+++ b/src/Reader/OffsetableDataInterface.php
@@ -6,5 +6,5 @@ namespace Yiisoft\Data\Reader;
 
 interface OffsetableDataInterface
 {
-    public function withOffset(int $offset): self;
+    public function withOffset(int $offset): static;
 }

--- a/src/Reader/ReadableDataInterface.php
+++ b/src/Reader/ReadableDataInterface.php
@@ -16,6 +16,8 @@ interface ReadableDataInterface
      * @param int $limit A limit of 0 means "no limit".
      *
      * @throws InvalidArgumentException if limit less than 0.
+     *
+     * @return static
      */
     public function withLimit(int $limit): static;
 

--- a/src/Reader/ReadableDataInterface.php
+++ b/src/Reader/ReadableDataInterface.php
@@ -8,7 +8,7 @@ use InvalidArgumentException;
 
 /**
  * @template TKey as array-key
- * @template TValue
+ * @template TValue as array|object
  */
 interface ReadableDataInterface
 {
@@ -27,7 +27,7 @@ interface ReadableDataInterface
     public function read(): iterable;
 
     /**
-     * @psalm-return TValue
+     * @psalm-return TValue|null
      */
-    public function readOne();
+    public function readOne(): array|object|null;
 }

--- a/src/Reader/ReadableDataInterface.php
+++ b/src/Reader/ReadableDataInterface.php
@@ -17,7 +17,7 @@ interface ReadableDataInterface
      *
      * @throws InvalidArgumentException if limit less than 0.
      */
-    public function withLimit(int $limit): self;
+    public function withLimit(int $limit): static;
 
     /**
      * @psalm-return iterable<TKey, TValue>

--- a/src/Reader/SortableDataInterface.php
+++ b/src/Reader/SortableDataInterface.php
@@ -6,7 +6,7 @@ namespace Yiisoft\Data\Reader;
 
 interface SortableDataInterface
 {
-    public function withSort(?Sort $sort): self;
+    public function withSort(?Sort $sort): static;
 
     public function getSort(): ?Sort;
 }

--- a/tests/Paginator/KeysetPaginatorTest.php
+++ b/tests/Paginator/KeysetPaginatorTest.php
@@ -525,7 +525,7 @@ final class KeysetPaginatorTest extends Testcase
                 return [];
             }
 
-            public function readOne()
+            public function readOne(): array|object|null
             {
                 return null;
             }
@@ -555,7 +555,7 @@ final class KeysetPaginatorTest extends Testcase
                 return [];
             }
 
-            public function readOne()
+            public function readOne(): array|object|null
             {
                 return null;
             }

--- a/tests/Paginator/KeysetPaginatorTest.php
+++ b/tests/Paginator/KeysetPaginatorTest.php
@@ -515,7 +515,7 @@ final class KeysetPaginatorTest extends Testcase
     private function getNonSortableDataReader()
     {
         return new class () implements ReadableDataInterface, FilterableDataInterface {
-            public function withLimit(int $limit): ReadableDataInterface
+            public function withLimit(int $limit): static
             {
                 return clone $this;
             }
@@ -530,12 +530,12 @@ final class KeysetPaginatorTest extends Testcase
                 return null;
             }
 
-            public function withFilter(FilterInterface $filter): FilterableDataInterface
+            public function withFilter(FilterInterface $filter): static
             {
                 return clone $this;
             }
 
-            public function withFilterProcessors(FilterProcessorInterface ...$filterUnits): FilterableDataInterface
+            public function withFilterProcessors(FilterProcessorInterface ...$filterUnits): static
             {
                 return clone $this;
             }
@@ -545,7 +545,7 @@ final class KeysetPaginatorTest extends Testcase
     private function getNonFilterableDataReader()
     {
         return new class () implements ReadableDataInterface, SortableDataInterface {
-            public function withLimit(int $limit): ReadableDataInterface
+            public function withLimit(int $limit): static
             {
                 return clone $this;
             }
@@ -560,7 +560,7 @@ final class KeysetPaginatorTest extends Testcase
                 return null;
             }
 
-            public function withSort(?Sort $sort): SortableDataInterface
+            public function withSort(?Sort $sort): static
             {
                 return clone $this;
             }

--- a/tests/Paginator/OffsetPaginatorTest.php
+++ b/tests/Paginator/OffsetPaginatorTest.php
@@ -47,7 +47,7 @@ final class OffsetPaginatorTest extends TestCase
     public function testDataReaderWithoutOffsetableInterface(): void
     {
         $nonOffsetableDataReader = new class () implements ReadableDataInterface, CountableDataInterface {
-            public function withLimit(int $limit): ReadableDataInterface
+            public function withLimit(int $limit): static
             {
                 // do nothing
             }
@@ -80,7 +80,7 @@ final class OffsetPaginatorTest extends TestCase
     public function testDataReaderWithoutCountableInterface(): void
     {
         $nonCountableDataReader = new class () implements ReadableDataInterface, OffsetableDataInterface {
-            public function withLimit(int $limit): ReadableDataInterface
+            public function withLimit(int $limit): static
             {
                 // do nothing
             }
@@ -100,7 +100,7 @@ final class OffsetPaginatorTest extends TestCase
                 return 0;
             }
 
-            public function withOffset(int $offset): self
+            public function withOffset(int $offset): static
             {
                 // do nothing
             }

--- a/tests/Paginator/OffsetPaginatorTest.php
+++ b/tests/Paginator/OffsetPaginatorTest.php
@@ -57,7 +57,7 @@ final class OffsetPaginatorTest extends TestCase
                 return [];
             }
 
-            public function readOne()
+            public function readOne(): array|object|null
             {
                 return null;
             }
@@ -90,7 +90,7 @@ final class OffsetPaginatorTest extends TestCase
                 return [];
             }
 
-            public function readOne()
+            public function readOne(): array|object|null
             {
                 return null;
             }

--- a/tests/Reader/Iterable/IterableDataReaderTest.php
+++ b/tests/Reader/Iterable/IterableDataReaderTest.php
@@ -376,7 +376,7 @@ final class IterableDataReaderTest extends TestCase
         };
 
         $reader = new class (self::DEFAULT_DATASET) extends IterableDataReader {
-            protected function matchFilter(array $item, array $filter): bool
+            protected function matchFilter(array|object $item, array $filter): bool
             {
                 [$operation, $field] = $filter;
 
@@ -416,7 +416,7 @@ final class IterableDataReaderTest extends TestCase
                         && $itemValue->getTimestamp() === $argumentValue->getTimestamp();
                 }
 
-                public function match(array $item, array $arguments, array $filterProcessors): bool
+                public function match(array|object $item, array $arguments, array $filterProcessors): bool
                 {
                     if (count($arguments) !== 2) {
                         throw new InvalidArgumentException('$arguments should contain exactly two elements.');
@@ -451,7 +451,7 @@ final class IterableDataReaderTest extends TestCase
                 parent::__construct($data);
             }
 
-            public function matchFilter(array $item, array $filter): bool
+            public function matchFilter(array|object $item, array $filter): bool
             {
                 return parent::matchFilter($item, $filter);
             }
@@ -485,6 +485,29 @@ final class IterableDataReaderTest extends TestCase
         $this->expectExceptionMessage('The operator string cannot be empty.');
 
         $dataReader->read();
+    }
+
+    public function testArrayOfObjects(): void
+    {
+        $data = [
+            'one' => new class() {
+                public int $a = 1;
+            },
+            'two' => new class() {
+                public int $a = 2;
+            },
+            'three' => new class() {
+                public int $a = 3;
+            },
+        ];
+
+        $reader = new IterableDataReader($data);
+
+        $rows = $reader->withFilter(new In('a', [2, 3]))->read();
+
+        $this->assertSame(['two', 'three'], array_keys($rows));
+        $this->assertSame(2, $rows['two']->a);
+        $this->assertSame(3, $rows['three']->a);
     }
 
     private function createFilterWithNotSupportedOperator(string $operator): FilterInterface

--- a/tests/Reader/Iterable/Processor/BetweenTest.php
+++ b/tests/Reader/Iterable/Processor/BetweenTest.php
@@ -20,7 +20,6 @@ final class BetweenTest extends TestCase
             [true, ['value', 45, 46]],
             [false, ['value', 46, 47]],
             [false, ['value', 46, 45]],
-            [false, ['not-exist', 42, 47]],
         ];
     }
 
@@ -47,7 +46,6 @@ final class BetweenTest extends TestCase
             [true, ['value', new DateTimeImmutable('2022-02-22 16:00:45'), new DateTimeImmutable('2022-02-22 16:00:46')]],
             [false, ['value', new DateTimeImmutable('2022-02-22 16:00:46'), new DateTimeImmutable('2022-02-22 16:00:47')]],
             [false, ['value', new DateTimeImmutable('2022-02-22 16:00:46'), new DateTimeImmutable('2022-02-22 16:00:45')]],
-            [false, ['not-exist', new DateTimeImmutable('2022-02-22 16:00:42'), new DateTimeImmutable('2022-02-22 16:00:47')]],
         ];
     }
 

--- a/tests/Reader/Iterable/Processor/EqualsEmptyTest.php
+++ b/tests/Reader/Iterable/Processor/EqualsEmptyTest.php
@@ -23,7 +23,6 @@ final class EqualsEmptyTest extends TestCase
             [false, ['value' => 42]],
             [false, ['value' => '1']],
             [false, ['value' => true]],
-            [true, ['not-exist' => 42]],
         ];
     }
 

--- a/tests/Reader/Iterable/Processor/EqualsNullTest.php
+++ b/tests/Reader/Iterable/Processor/EqualsNullTest.php
@@ -22,7 +22,6 @@ final class EqualsNullTest extends TestCase
             [false, ['value' => 42]],
             [false, ['value' => '']],
             [false, ['value' => 'null']],
-            [false, ['not-exist' => null]],
         ];
     }
 

--- a/tests/Reader/Iterable/Processor/EqualsTest.php
+++ b/tests/Reader/Iterable/Processor/EqualsTest.php
@@ -19,7 +19,6 @@ final class EqualsTest extends TestCase
             [true, ['value', '45']],
             [false, ['value', 44]],
             [false, ['value', 46]],
-            [false, ['not-exist', 45]],
         ];
     }
 
@@ -44,7 +43,6 @@ final class EqualsTest extends TestCase
             [true, ['value', new DateTimeImmutable('2022-02-22 16:00:45')]],
             [false, ['value', new DateTimeImmutable('2022-02-22 16:00:44')]],
             [false, ['value', new DateTimeImmutable('2022-02-22 16:00:46')]],
-            [false, ['not-exist', new DateTimeImmutable('2022-02-22 16:00:45')]],
         ];
     }
 

--- a/tests/Reader/Iterable/Processor/GreaterThanOrEqualTest.php
+++ b/tests/Reader/Iterable/Processor/GreaterThanOrEqualTest.php
@@ -19,7 +19,6 @@ final class GreaterThanOrEqualTest extends TestCase
             [true, ['value', 45]],
             [true, ['value', '45']],
             [false, ['value', 46]],
-            [false, ['not-exist', 44]],
         ];
     }
 
@@ -44,7 +43,6 @@ final class GreaterThanOrEqualTest extends TestCase
             [true, ['value', new DateTimeImmutable('2022-02-22 16:00:44')]],
             [true, ['value', new DateTimeImmutable('2022-02-22 16:00:45')]],
             [false, ['value', new DateTimeImmutable('2022-02-22 16:00:46')]],
-            [false, ['not-exist', new DateTimeImmutable('2022-02-22 16:00:44')]],
         ];
     }
 

--- a/tests/Reader/Iterable/Processor/GreaterThanTest.php
+++ b/tests/Reader/Iterable/Processor/GreaterThanTest.php
@@ -19,7 +19,6 @@ final class GreaterThanTest extends TestCase
             [true, ['value', '44']],
             [false, ['value', 45]],
             [false, ['value', 46]],
-            [false, ['not-exist', 44]],
         ];
     }
 
@@ -44,7 +43,6 @@ final class GreaterThanTest extends TestCase
             [true, ['value', new DateTimeImmutable('2022-02-22 16:00:44')]],
             [false, ['value', new DateTimeImmutable('2022-02-22 16:00:45')]],
             [false, ['value', new DateTimeImmutable('2022-02-22 16:00:46')]],
-            [false, ['not-exist', new DateTimeImmutable('2022-02-22 16:00:44')]],
         ];
     }
 

--- a/tests/Reader/Iterable/Processor/InTest.php
+++ b/tests/Reader/Iterable/Processor/InTest.php
@@ -17,7 +17,6 @@ final class InTest extends TestCase
             [true, ['value', [44, 45, 46]]],
             [true, ['value', [44, '45', 46]]],
             [false, ['value', [1, 2, 3]]],
-            [false, ['not-exist', [45]]],
         ];
     }
 

--- a/tests/Reader/Iterable/Processor/LessThanOrEqualTest.php
+++ b/tests/Reader/Iterable/Processor/LessThanOrEqualTest.php
@@ -19,7 +19,6 @@ final class LessThanOrEqualTest extends TestCase
             [true, ['value', 45]],
             [true, ['value', '45']],
             [false, ['value', 44]],
-            [false, ['not-exist', 46]],
         ];
     }
 
@@ -44,7 +43,6 @@ final class LessThanOrEqualTest extends TestCase
             [true, ['value', new DateTimeImmutable('2022-02-22 16:00:46')]],
             [true, ['value', new DateTimeImmutable('2022-02-22 16:00:45')]],
             [false, ['value', new DateTimeImmutable('2022-02-22 16:00:44')]],
-            [false, ['not-exist', new DateTimeImmutable('2022-02-22 16:00:46')]],
         ];
     }
 

--- a/tests/Reader/Iterable/Processor/LessThanTest.php
+++ b/tests/Reader/Iterable/Processor/LessThanTest.php
@@ -19,7 +19,6 @@ final class LessThanTest extends TestCase
             [true, ['value', '46']],
             [false, ['value', 45]],
             [false, ['value', 44]],
-            [false, ['not-exist', 46]],
         ];
     }
 
@@ -44,7 +43,6 @@ final class LessThanTest extends TestCase
             [true, ['value', new DateTimeImmutable('2022-02-22 16:00:46')]],
             [false, ['value', new DateTimeImmutable('2022-02-22 16:00:45')]],
             [false, ['value', new DateTimeImmutable('2022-02-22 16:00:44')]],
-            [false, ['not-exist', new DateTimeImmutable('2022-02-22 16:00:46')]],
         ];
     }
 

--- a/tests/Reader/Iterable/Processor/LikeTest.php
+++ b/tests/Reader/Iterable/Processor/LikeTest.php
@@ -18,7 +18,6 @@ final class LikeTest extends TestCase
             [true, ['value', 'Cat']],
             [false, ['id', 1]],
             [false, ['id', '1']],
-            [false, ['not-exist', 'Fighter42']],
         ];
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ✔️
| Breaks BC?    | ✔️
| Fixed issues  | #107 

- fixed psalm errors
- in `with*` methods change return type hint from `self` to `static`
- add support of object arrays to `IterableDataReader`
