### PR TITLE
Fix #124: Throw exception in IterableDataReader::withFilterHandlers() if non-iterable filter handler is supplied

### DIFF
--- a/src/Reader/Iterable/IterableDataReader.php
+++ b/src/Reader/Iterable/IterableDataReader.php
@@ -9,6 +9,7 @@ use InvalidArgumentException;
 use RuntimeException;
 use Traversable;
 use Yiisoft\Arrays\ArrayHelper;
+use Yiisoft\Data\Reader\DataReaderException;
 use Yiisoft\Data\Reader\DataReaderInterface;
 use Yiisoft\Data\Reader\FilterHandlerInterface;
 use Yiisoft\Data\Reader\FilterInterface;
@@ -90,9 +91,15 @@ class IterableDataReader implements DataReaderInterface
         $handlers = [];
 
         foreach ($iterableFilterHandlers as $iterableFilterHandler) {
-            if ($iterableFilterHandler instanceof IterableFilterHandlerInterface) {
-                $handlers[$iterableFilterHandler->getOperator()] = $iterableFilterHandler;
+            if (!$iterableFilterHandler instanceof IterableFilterHandlerInterface) {
+                $message = sprintf(
+                    '%s::withFilterHandlers() accepts instances of %s only.',
+                    static::class,
+                    IterableFilterHandlerInterface::class
+                );
+                throw new DataReaderException($message);
             }
+            $handlers[$iterableFilterHandler->getOperator()] = $iterableFilterHandler;
         }
 
         $new->iterableFilterHandlers = array_merge($this->iterableFilterHandlers, $handlers);

--- a/tests/Reader/IterableDataReaderTest.php
+++ b/tests/Reader/IterableDataReaderTest.php
@@ -9,6 +9,7 @@ use DateTimeInterface;
 use Generator;
 use InvalidArgumentException;
 use RuntimeException;
+use Yiisoft\Data\Reader\DataReaderException;
 use Yiisoft\Data\Reader\Filter\All;
 use Yiisoft\Data\Reader\Filter\Any;
 use Yiisoft\Data\Reader\Filter\Equals;
@@ -20,9 +21,11 @@ use Yiisoft\Data\Reader\Filter\LessThanOrEqual;
 use Yiisoft\Data\Reader\Filter\Like;
 use Yiisoft\Data\Reader\Filter\Not;
 use Yiisoft\Data\Reader\FilterAssert;
+use Yiisoft\Data\Reader\FilterHandlerInterface;
 use Yiisoft\Data\Reader\FilterInterface;
 use Yiisoft\Data\Reader\Iterable\FilterHandler\Compare;
 use Yiisoft\Data\Reader\Iterable\IterableDataReader;
+use Yiisoft\Data\Reader\Iterable\IterableFilterHandlerInterface;
 use Yiisoft\Data\Reader\Sort;
 use Yiisoft\Data\Tests\TestCase;
 
@@ -70,6 +73,27 @@ final class IterableDataReaderTest extends TestCase
         $this->assertNotSame($reader, $reader->withSort(null));
         $this->assertNotSame($reader, $reader->withOffset(1));
         $this->assertNotSame($reader, $reader->withLimit(1));
+    }
+
+    public function testExceptionOnPassingNonIterableFilters(): void
+    {
+        $nonIterableFilterHandler = new class implements FilterHandlerInterface {
+
+            public function getOperator(): string
+            {
+                return '?';
+            }
+        };
+
+        $this->expectException(DataReaderException::class);
+        $message = sprintf(
+            '%s::withFilterHandlers() accepts instances of %s only.',
+            IterableDataReader::class,
+            IterableFilterHandlerInterface::class
+        );
+        $this->expectExceptionMessage($message);
+
+        (new IterableDataReader([]))->withFilterHandlers($nonIterableFilterHandler);
     }
 
     public function testWithLimitFailForNegativeValues(): void

--- a/tests/Reader/IterableDataReaderTest.php
+++ b/tests/Reader/IterableDataReaderTest.php
@@ -77,8 +77,7 @@ final class IterableDataReaderTest extends TestCase
 
     public function testExceptionOnPassingNonIterableFilters(): void
     {
-        $nonIterableFilterHandler = new class implements FilterHandlerInterface {
-
+        $nonIterableFilterHandler = new class () implements FilterHandlerInterface {
             public function getOperator(): string
             {
                 return '?';


### PR DESCRIPTION


| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | #124
