### PR TITLE
Rename `isRequired()` method in `PaginatorInterface` to `isPaginationRequired()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - New #150: Extract `withLimit()` from `ReadableDataInterface` into `LimitableDataInterface` (@vjik)
 - Enh #150: `PaginatorInterface` now extends `ReadableDataInterface` (@vjik)
+- Chg #151: Rename `isRequired()` method in `PaginatorInterface` to `isPaginationRequired()` (@vjik)
 
 ## 1.0.1 January 25, 2023
 

--- a/src/Paginator/KeysetPaginator.php
+++ b/src/Paginator/KeysetPaginator.php
@@ -245,7 +245,7 @@ final class KeysetPaginator implements PaginatorInterface
         return !$this->hasNextPage;
     }
 
-    public function isRequired(): bool
+    public function isPaginationRequired(): bool
     {
         return !$this->isOnFirstPage() || !$this->isOnLastPage();
     }

--- a/src/Paginator/OffsetPaginator.php
+++ b/src/Paginator/OffsetPaginator.php
@@ -243,7 +243,7 @@ final class OffsetPaginator implements PaginatorInterface
         return $this->currentPage === $this->getInternalTotalPages();
     }
 
-    public function isRequired(): bool
+    public function isPaginationRequired(): bool
     {
         return $this->getTotalPages() > 1;
     }

--- a/src/Paginator/PaginatorInterface.php
+++ b/src/Paginator/PaginatorInterface.php
@@ -130,5 +130,5 @@ interface PaginatorInterface extends ReadableDataInterface
      *
      * @return bool Whether pagination is required.
      */
-    public function isRequired(): bool;
+    public function isPaginationRequired(): bool;
 }

--- a/tests/Paginator/KeysetPaginatorTest.php
+++ b/tests/Paginator/KeysetPaginatorTest.php
@@ -393,7 +393,7 @@ final class KeysetPaginatorTest extends Testcase
         $paginator = (new KeysetPaginator($dataReader))->withPageSize(2);
 
         $this->assertTrue($paginator->isOnFirstPage());
-        $this->assertTrue($paginator->isRequired());
+        $this->assertTrue($paginator->isPaginationRequired());
     }
 
     public function testIsOnLastPage(): void
@@ -416,20 +416,20 @@ final class KeysetPaginatorTest extends Testcase
 
         $paginator = $paginator->withNextPageToken('2');
         $this->assertFalse($paginator->isOnLastPage());
-        $this->assertTrue($paginator->isRequired());
+        $this->assertTrue($paginator->isPaginationRequired());
     }
 
-    public function testIsRequired(): void
+    public function testIsPaginationRequired(): void
     {
         $sort = Sort::only(['id'])->withOrderString('id');
         $dataReader = (new IterableDataReader($this->getDataSet()))->withSort($sort);
         $paginator = new KeysetPaginator($dataReader);
 
-        $this->assertFalse($paginator->isRequired());
+        $this->assertFalse($paginator->isPaginationRequired());
 
         $paginator = $paginator->withPageSize(2);
 
-        $this->assertTrue($paginator->isRequired());
+        $this->assertTrue($paginator->isPaginationRequired());
     }
 
     public function testCurrentPageSize(): void

--- a/tests/Paginator/OffsetPaginatorTest.php
+++ b/tests/Paginator/OffsetPaginatorTest.php
@@ -167,15 +167,15 @@ final class OffsetPaginatorTest extends TestCase
         $this->assertSame(0, $paginator->getOffset());
         $this->assertSame(1, $paginator->getCurrentPage());
         $this->assertTrue($paginator->isOnFirstPage());
-        $this->assertFalse($paginator->isRequired());
+        $this->assertFalse($paginator->isPaginationRequired());
     }
 
-    public function testIsRequired(): void
+    public function testIsPaginationRequired(): void
     {
         $dataReader = new IterableDataReader(self::DEFAULT_DATASET);
         $paginator = (new OffsetPaginator($dataReader))->withPageSize(2);
 
-        $this->assertTrue($paginator->isRequired());
+        $this->assertTrue($paginator->isPaginationRequired());
     }
 
     public function testGetTotalItems(): void
@@ -463,7 +463,7 @@ final class OffsetPaginatorTest extends TestCase
         $this->assertSame(1, $paginator->getCurrentPage());
         $this->assertTrue($paginator->isOnFirstPage());
         $this->assertTrue($paginator->isOnLastPage());
-        $this->assertFalse($paginator->isRequired());
+        $this->assertFalse($paginator->isPaginationRequired());
         $this->assertSame([], $this->iterableToArray($paginator->read()));
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ✔️

It's more clear, because paginator used as reader.
For example:

```php
$dataReader->isRequired();
// vs
$dataReader->isPaginationRequired();
```