### PR TITLE
Add optional `$extend` parameter to `Sort::getOrderString()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
 - Chg #154: Raise minimum required PHP version to 8.1 (@vjik)
 - Bug #155: Fix `Sort` configuration preparation (@vjik)
 - Bug #155: Fix same named order fields in `Sort` were not overriding previous ones (@vjik)
+- New #157: Add optional `$extend` parameter to `Sort::getOrderString()` method that allow define extra order that 
+  will merge with current order before make order string (@vjik)
 
 ## 1.0.1 January 25, 2023
 

--- a/src/Reader/Sort.php
+++ b/src/Reader/Sort.php
@@ -285,13 +285,19 @@ final class Sort
      * If the name is prefixed with `-`, field order is descending.
      * Otherwise, the order is ascending.
      *
+     * @param array $extend A map with logical field names to order by as keys, direction ("asc" or "desc") as values.
+     * This map will be merged with current order before make order string.
+     *
      * @return string An order string.
+     *
+     * @psalm-param TOrder $extend
      */
-    public function getOrderAsString(): string
+    public function getOrderAsString(array $extend = []): string
     {
         $parts = [];
 
-        foreach ($this->currentOrder as $field => $direction) {
+        $order = array_merge($this->currentOrder, $extend);
+        foreach ($order as $field => $direction) {
             $parts[] = ($direction === 'desc' ? '-' : '') . $field;
         }
 

--- a/tests/Reader/SortTest.php
+++ b/tests/Reader/SortTest.php
@@ -114,7 +114,7 @@ final class SortTest extends TestCase
                     'b' => 'asc',
                 ],
                 [
-                    'a' => 'asc'
+                    'a' => 'asc',
                 ],
             ],
             [

--- a/tests/Reader/SortTest.php
+++ b/tests/Reader/SortTest.php
@@ -96,7 +96,50 @@ final class SortTest extends TestCase
         ], $sort->getOrder());
     }
 
-    public function testGetOrderAsString(): void
+    public static function dataGetOrderAsString(): array
+    {
+        return [
+            [
+                '-a,b',
+                [
+                    'a' => 'desc',
+                    'b' => 'asc',
+                ],
+                [],
+            ],
+            [
+                'a,b',
+                [
+                    'a' => 'desc',
+                    'b' => 'asc',
+                ],
+                [
+                    'a' => 'asc'
+                ],
+            ],
+            [
+                'a,b,-c',
+                [
+                    'a' => 'desc',
+                    'b' => 'asc',
+                ],
+                [
+                    'a' => 'asc',
+                    'c' => 'desc',
+                ],
+            ],
+        ];
+    }
+
+    #[DataProvider('dataGetOrderAsString')]
+    public function testGetOrderAsString(string $expected, array $order, array $extend): void
+    {
+        $sort = Sort::any()->withOrder($order);
+
+        $this->assertSame($expected, $sort->getOrderAsString($extend));
+    }
+
+    public function testGetOrderAsStringDefault(): void
     {
         $sort = Sort::any()->withOrder([
             'a' => 'desc',


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌
| Fixed issues  | -
