### PR TITLE
Fix #163: Rename FilterableDataInterface::withFilterHandlers() to FilterableDataInterface::withAddedFilterHandlers()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 - New #176: Add `OrderHelper` (@vjik)
 - New #173, #184: Add `$caseSensitive` parameter to `Like` filter to control whether the search must be case-sensitive
   or not (@arogachev)
+- Chg #163: Rename `FilterableDataInterface::withFilterHandlers()` to `FilterableDataInterface::withAddedFilterHandlers()` (@samdark)
 
 ## 1.0.1 January 25, 2023
 

--- a/src/Reader/FilterableDataInterface.php
+++ b/src/Reader/FilterableDataInterface.php
@@ -35,5 +35,5 @@ interface FilterableDataInterface
      * @return static New instance.
      * @psalm-return $this
      */
-    public function withFilterHandlers(FilterHandlerInterface ...$filterHandlers): static;
+    public function withAddedFilterHandlers(FilterHandlerInterface ...$filterHandlers): static;
 }

--- a/src/Reader/Iterable/IterableDataReader.php
+++ b/src/Reader/Iterable/IterableDataReader.php
@@ -84,7 +84,7 @@ final class IterableDataReader implements DataReaderInterface
     /**
      * @psalm-return $this
      */
-    public function withFilterHandlers(FilterHandlerInterface ...$filterHandlers): static
+    public function withAddedFilterHandlers(FilterHandlerInterface ...$filterHandlers): static
     {
         $new = clone $this;
         $new->iterableFilterHandlers = array_merge(

--- a/tests/Paginator/KeysetPaginatorTest.php
+++ b/tests/Paginator/KeysetPaginatorTest.php
@@ -116,7 +116,7 @@ final class KeysetPaginatorTest extends Testcase
                 return clone $this;
             }
 
-            public function withFilterHandlers(FilterHandlerInterface ...$filterHandlers): static
+            public function withAddedFilterHandlers(FilterHandlerInterface ...$filterHandlers): static
             {
                 return clone $this;
             }
@@ -603,7 +603,7 @@ final class KeysetPaginatorTest extends Testcase
                 return clone $this;
             }
 
-            public function withFilterHandlers(FilterHandlerInterface ...$filterHandlers): static
+            public function withAddedFilterHandlers(FilterHandlerInterface ...$filterHandlers): static
             {
                 return clone $this;
             }

--- a/tests/Reader/Iterable/IterableDataReaderTest.php
+++ b/tests/Reader/Iterable/IterableDataReaderTest.php
@@ -67,7 +67,7 @@ final class IterableDataReaderTest extends TestCase
     {
         $reader = new IterableDataReader([]);
 
-        $this->assertNotSame($reader, $reader->withFilterHandlers());
+        $this->assertNotSame($reader, $reader->withAddedFilterHandlers());
         $this->assertNotSame($reader, $reader->withFilter(null));
         $this->assertNotSame($reader, $reader->withSort(null));
         $this->assertNotSame($reader, $reader->withOffset(1));
@@ -91,7 +91,7 @@ final class IterableDataReaderTest extends TestCase
         );
         $this->expectExceptionMessage($message);
 
-        (new IterableDataReader([]))->withFilterHandlers($nonIterableFilterHandler);
+        (new IterableDataReader([]))->withAddedFilterHandlers($nonIterableFilterHandler);
     }
 
     public function testWithLimitFailForNegativeValues(): void
@@ -383,7 +383,7 @@ final class IterableDataReaderTest extends TestCase
     public function testCustomFilter(): void
     {
         $reader = (new IterableDataReader(self::DEFAULT_DATASET))
-            ->withFilterHandlers(new DigitalHandler())
+            ->withAddedFilterHandlers(new DigitalHandler())
             ->withFilter(
                 new All(new GreaterThan('id', 0), new Digital('name'))
             );
@@ -398,7 +398,7 @@ final class IterableDataReaderTest extends TestCase
 
         $dataReader = (new IterableDataReader(self::DEFAULT_DATASET))
             ->withSort($sort)
-            ->withFilterHandlers(
+            ->withAddedFilterHandlers(
                 new class () implements IterableFilterHandlerInterface {
                     public function getFilterClass(): string
                     {

--- a/tests/Support/MutationDataReader.php
+++ b/tests/Support/MutationDataReader.php
@@ -33,10 +33,10 @@ final class MutationDataReader implements
         return $new;
     }
 
-    public function withFilterHandlers(FilterHandlerInterface ...$filterHandlers): static
+    public function withAddedFilterHandlers(FilterHandlerInterface ...$filterHandlers): static
     {
         $new = clone $this;
-        $new->decorated = $this->decorated->withFilterHandlers(...$filterHandlers);
+        $new->decorated = $this->decorated->withAddedFilterHandlers(...$filterHandlers);
         return $new;
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ✔️
