### PR TITLE
Fix invalid count in `IterableDataReader` when limit or/and offset used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
   value meaning `return nothing` (@samdark)
 - Chg #163: Rename `FilterableDataInterface::withFilterHandlers()` to `FilterableDataInterface::withAddedFilterHandlers()` (@samdark)
 - Enh #190: Use `str_contains` for case-sensitive match in `LikeHandler` (@samdark)
+- Bug #195: Fix invalid count in `IterableDataReader` when limit or/and offset used (@vjik) 
 
 ## 1.0.1 January 25, 2023
 

--- a/src/Reader/Iterable/IterableDataReader.php
+++ b/src/Reader/Iterable/IterableDataReader.php
@@ -177,6 +177,9 @@ final class IterableDataReader implements DataReaderInterface
             ->current();
     }
 
+    /**
+     * @psalm-return array<TKey, TValue>
+     */
     private function internalRead(bool $useLimitAndOffset): array
     {
         $data = [];

--- a/src/Reader/Iterable/IterableDataReader.php
+++ b/src/Reader/Iterable/IterableDataReader.php
@@ -170,7 +170,7 @@ final class IterableDataReader implements DataReaderInterface
             return null;
         }
 
-        /** @infection-ignore-all Any value more one in `withLimit()` will be ignored because returned `current()` */
+        /** @infection-ignore-all Any value more than one in `withLimit()` will be ignored because returned `current()` */
         return $this
             ->withLimit(1)
             ->getIterator()

--- a/tests/Reader/Iterable/IterableDataReaderTest.php
+++ b/tests/Reader/Iterable/IterableDataReaderTest.php
@@ -169,6 +169,20 @@ final class IterableDataReaderTest extends TestCase
         $this->assertCount(5, $reader);
     }
 
+    public function testCountWithLimit(): void
+    {
+        $reader = (new IterableDataReader(self::DEFAULT_DATASET))->withLimit(2);
+        $this->assertSame(5, $reader->count());
+        $this->assertCount(5, $reader);
+    }
+
+    public function testCountWithOffset(): void
+    {
+        $reader = (new IterableDataReader(self::DEFAULT_DATASET))->withOffset(3);
+        $this->assertSame(5, $reader->count());
+        $this->assertCount(5, $reader);
+    }
+
     public function testReadOne(): void
     {
         $data = self::DEFAULT_DATASET;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
