### PR TITLE
Fix #202: Check that correct sort is passed to `withSort()` of keyset paginator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,8 @@
 - Chg #163: Rename `FilterableDataInterface::withFilterHandlers()` to `FilterableDataInterface::withAddedFilterHandlers()` (@samdark)
 - Enh #190: Use `str_contains` for case-sensitive match in `LikeHandler` (@samdark)
 - Enh #194: Improve psalm annotations in `LimitableDataInterface` (@vjik)
-- Bug #195: Fix invalid count in `IterableDataReader` when limit or/and offset used (@vjik) 
+- Bug #195: Fix invalid count in `IterableDataReader` when limit or/and offset used (@vjik)
+- Enh #202: Check that correct sort is passed to `withSort()` of keyset paginator (@samdark)
 
 ## 1.0.1 January 25, 2023
 

--- a/src/Paginator/KeysetPaginator.php
+++ b/src/Paginator/KeysetPaginator.php
@@ -122,14 +122,7 @@ final class KeysetPaginator implements PaginatorInterface
         }
 
         $sort = $dataReader->getSort();
-
-        if ($sort === null) {
-            throw new InvalidArgumentException('Data sorting should be configured to work with keyset pagination.');
-        }
-
-        if (empty($sort->getOrder())) {
-            throw new InvalidArgumentException('Data should be always sorted to work with keyset pagination.');
-        }
+        $this->assertSort($sort);
 
         $this->dataReader = $dataReader;
     }
@@ -261,13 +254,7 @@ final class KeysetPaginator implements PaginatorInterface
 
     public function withSort(?Sort $sort): static
     {
-        if ($sort === null) {
-            throw new InvalidArgumentException('Data sorting should be configured to work with keyset pagination.');
-        }
-
-        if (empty($sort->getOrder())) {
-            throw new InvalidArgumentException('Data should be always sorted to work with keyset pagination.');
-        }
+        $this->assertSort($sort);
 
         $new = clone $this;
         $new->dataReader = $this->dataReader->withSort($sort);
@@ -446,5 +433,16 @@ final class KeysetPaginator implements PaginatorInterface
             (string) key($order),
             reset($order) === 'asc' ? SORT_ASC : SORT_DESC,
         ];
+    }
+
+    private function assertSort(?Sort $sort): void
+    {
+        if ($sort === null) {
+            throw new InvalidArgumentException('Data sorting should be configured to work with keyset pagination.');
+        }
+
+        if (empty($sort->getOrder())) {
+            throw new InvalidArgumentException('Data should be always sorted to work with keyset pagination.');
+        }
     }
 }

--- a/src/Paginator/KeysetPaginator.php
+++ b/src/Paginator/KeysetPaginator.php
@@ -125,11 +125,11 @@ final class KeysetPaginator implements PaginatorInterface
         $sort = $dataReader->getSort();
 
         if ($sort === null) {
-            throw new RuntimeException('Data sorting should be configured to work with keyset pagination.');
+            throw new InvalidArgumentException('Data sorting should be configured to work with keyset pagination.');
         }
 
         if (empty($sort->getOrder())) {
-            throw new RuntimeException('Data should be always sorted to work with keyset pagination.');
+            throw new InvalidArgumentException('Data should be always sorted to work with keyset pagination.');
         }
 
         $this->dataReader = $dataReader;
@@ -262,6 +262,14 @@ final class KeysetPaginator implements PaginatorInterface
 
     public function withSort(?Sort $sort): static
     {
+        if ($sort === null) {
+            throw new InvalidArgumentException('Data sorting should be configured to work with keyset pagination.');
+        }
+
+        if (empty($sort->getOrder())) {
+            throw new InvalidArgumentException('Data should be always sorted to work with keyset pagination.');
+        }
+
         $new = clone $this;
         $new->dataReader = $this->dataReader->withSort($sort);
         return $new;

--- a/src/Paginator/KeysetPaginator.php
+++ b/src/Paginator/KeysetPaginator.php
@@ -6,7 +6,6 @@ namespace Yiisoft\Data\Paginator;
 
 use Closure;
 use InvalidArgumentException;
-use RuntimeException;
 use Yiisoft\Arrays\ArrayHelper;
 use Yiisoft\Data\Reader\Filter\GreaterThan;
 use Yiisoft\Data\Reader\Filter\GreaterThanOrEqual;

--- a/tests/Paginator/KeysetPaginatorTest.php
+++ b/tests/Paginator/KeysetPaginatorTest.php
@@ -149,10 +149,21 @@ final class KeysetPaginatorTest extends Testcase
     {
         $dataReader = new IterableDataReader(self::getDataSet());
 
-        $this->expectException(RuntimeException::class);
+        $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Data sorting should be configured to work with keyset pagination.');
 
         new KeysetPaginator($dataReader);
+    }
+
+    public function testThrowsExceptionForWithSortNull(): void
+    {
+        $sort = Sort::only(['id', 'name'])->withOrderString('id');
+        $dataReader = (new IterableDataReader(self::getDataSet()))->withSort($sort);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Data sorting should be configured to work with keyset pagination.');
+
+        (new KeysetPaginator($dataReader))->withSort(null);
     }
 
     public function testThrowsExceptionWhenNotSorted(): void
@@ -160,10 +171,21 @@ final class KeysetPaginatorTest extends Testcase
         $sort = Sort::only(['id', 'name']);
         $dataReader = (new IterableDataReader(self::getDataSet()))->withSort($sort);
 
-        $this->expectException(RuntimeException::class);
+        $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Data should be always sorted to work with keyset pagination.');
 
         new KeysetPaginator($dataReader);
+    }
+
+    public function testThrowsExceptionForWithSortNotSorted(): void
+    {
+        $sort = Sort::only(['id', 'name'])->withOrderString('id');
+        $dataReader = (new IterableDataReader(self::getDataSet()))->withSort($sort);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Data should be always sorted to work with keyset pagination.');
+
+        (new KeysetPaginator($dataReader))->withSort(Sort::only(['id', 'name']));
     }
 
     public function testPageSizeCannotBeLessThanOne(): void


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ❌
