### PR TITLE
Throw `PageNotFoundException` instead of `PaginatorException` in `OfferPaginator::withCurrentPage()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,8 @@
 - Enh #214: Improved interface hierarchy (@samdark)
 - Enh #207: More specific Psalm type for `OffsetPaginator::withCurrentPage()` parameter (@samdark)
 - Enh #210: More specific Psalm type for `PaginatorInterface::getPageSize()` result (@vjik)
+- Enh #219: Add ability to set custom message in `PageNotFoundException` (@vjik)
+- Enh #219: Throw `PageNotFoundException` instead of `PaginatorException` in `OfferPaginator::withCurrentPage()` (@vjik)
 
 ## 1.0.1 January 25, 2023
 

--- a/src/Paginator/OffsetPaginator.php
+++ b/src/Paginator/OffsetPaginator.php
@@ -115,7 +115,7 @@ final class OffsetPaginator implements PaginatorInterface
      * @param int $page Page number.
      * @psalm-param positive-int $page
      *
-     * @throws PaginatorException If the current page is incorrect.
+     * @throws PageNotFoundException If the current page is zero or less.
      *
      * @return self New instance.
      */
@@ -123,7 +123,7 @@ final class OffsetPaginator implements PaginatorInterface
     {
         /** @psalm-suppress DocblockTypeContradiction */
         if ($page < 1) {
-            throw new PaginatorException('Current page should be at least 1.');
+            throw new PageNotFoundException('Current page should be at least 1.');
         }
 
         $new = clone $this;
@@ -276,8 +276,11 @@ final class OffsetPaginator implements PaginatorInterface
      */
     public function read(): iterable
     {
-        if ($this->getCurrentPage() > $this->getInternalTotalPages()) {
-            throw new PageNotFoundException();
+        $currentPage = $this->getCurrentPage();
+        if ($currentPage > $this->getInternalTotalPages()) {
+            throw new PageNotFoundException(
+                sprintf('Page %d not found.', $currentPage)
+            );
         }
 
         $limit = $this->pageSize;
@@ -316,11 +319,14 @@ final class OffsetPaginator implements PaginatorInterface
 
     public function isOnLastPage(): bool
     {
-        if ($this->getCurrentPage() > $this->getInternalTotalPages()) {
-            throw new PageNotFoundException();
+        $currentPage = $this->getCurrentPage();
+        if ($currentPage > $this->getInternalTotalPages()) {
+            throw new PageNotFoundException(
+                sprintf('Page %d not found.', $currentPage)
+            );
         }
 
-        return $this->getCurrentPage() === $this->getInternalTotalPages();
+        return $currentPage === $this->getInternalTotalPages();
     }
 
     public function isPaginationRequired(): bool

--- a/src/Paginator/PageNotFoundException.php
+++ b/src/Paginator/PageNotFoundException.php
@@ -6,8 +6,8 @@ namespace Yiisoft\Data\Paginator;
 
 final class PageNotFoundException extends PaginatorException
 {
-    public function __construct()
+    public function __construct(string $message = 'Page not found.')
     {
-        parent::__construct('Page not found.');
+        parent::__construct($message);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ❌
