### PR TITLE
Remove nullable types from `withFilter()` and `getFilter()` methods of `FilterableDataInterface`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@
 - New #213: Add `nextPage()` and `previousPage()` methods to `PaginatorInterface` (@samdark)
 - New #200: Add matching mode parameter to `Like` filter (@samdark, @vjik)
 - New #232: Add `All` and `None` filters (@vjik)
+- Chg #233: Remove nullable types from `withFilter()` and `getFilter()` methods of `FilterableDataInterface` (@vjik)
 
 ## 1.0.1 January 25, 2023
 

--- a/composer.json
+++ b/composer.json
@@ -37,8 +37,8 @@
     },
     "require-dev": {
         "maglnet/composer-require-checker": "^4.7.1",
-        "phpunit/phpunit": "^10.5.48",
-        "rector/rector": "^2.1.2",
+        "phpunit/phpunit": "^10.5.52",
+        "rector/rector": "^2.1.4",
         "roave/infection-static-analysis-plugin": "^1.35",
         "spatie/phpunit-watcher": "^1.24",
         "vimeo/psalm": "^5.26.1 || ^6.10.3"

--- a/src/Reader/FilterableDataInterface.php
+++ b/src/Reader/FilterableDataInterface.php
@@ -25,19 +25,18 @@ interface FilterableDataInterface extends ReadableDataInterface
     /**
      * Returns new instance with data reading criteria set.
      *
-     * @param ?FilterInterface $filter Data reading criteria.
+     * @param FilterInterface $filter Data reading criteria.
      *
      * @return static New instance.
-     * @psalm-return $this
      */
-    public function withFilter(?FilterInterface $filter): static;
+    public function withFilter(FilterInterface $filter): static;
 
     /**
      * Get current data reading criteria.
      *
-     * @return FilterInterface|null Data reading criteria.
+     * @return FilterInterface Data reading criteria.
      */
-    public function getFilter(): ?FilterInterface;
+    public function getFilter(): FilterInterface;
 
     /**
      * Returns new instance with additional handlers set.
@@ -45,7 +44,6 @@ interface FilterableDataInterface extends ReadableDataInterface
      * @param FilterHandlerInterface ...$filterHandlers Additional filter handlers.
      *
      * @return static New instance.
-     * @psalm-return $this
      */
     public function withAddedFilterHandlers(FilterHandlerInterface ...$filterHandlers): static;
 }

--- a/src/Reader/Iterable/IterableDataReader.php
+++ b/src/Reader/Iterable/IterableDataReader.php
@@ -10,6 +10,7 @@ use Traversable;
 use Yiisoft\Arrays\ArrayHelper;
 use Yiisoft\Data\Reader\DataReaderException;
 use Yiisoft\Data\Reader\DataReaderInterface;
+use Yiisoft\Data\Reader\Filter\All;
 use Yiisoft\Data\Reader\FilterHandlerInterface;
 use Yiisoft\Data\Reader\FilterInterface;
 use Yiisoft\Data\Reader\Iterable\FilterHandler\AllHandler;
@@ -53,7 +54,7 @@ use function uasort;
 final class IterableDataReader implements DataReaderInterface
 {
     private ?Sort $sort = null;
-    private ?FilterInterface $filter = null;
+    private FilterInterface $filter;
 
     /**
      * @psalm-var non-negative-int|null
@@ -93,6 +94,7 @@ final class IterableDataReader implements DataReaderInterface
             new NotHandler(),
         ]);
         $this->context = new Context($this->coreFilterHandlers, $this->valueReader);
+        $this->filter = new All();
     }
 
     /**
@@ -111,10 +113,7 @@ final class IterableDataReader implements DataReaderInterface
         return $new;
     }
 
-    /**
-     * @psalm-return $this
-     */
-    public function withFilter(?FilterInterface $filter): static
+    public function withFilter(FilterInterface $filter): static
     {
         $new = clone $this;
         $new->filter = $filter;
@@ -216,8 +215,8 @@ final class IterableDataReader implements DataReaderInterface
                 continue;
             }
 
-            // Filter items.
-            if ($this->filter === null || $this->matchFilter($item, $this->filter)) {
+            // Filter items
+            if ($this->matchFilter($item, $this->filter)) {
                 $data[$key] = $item;
             }
         }
@@ -320,7 +319,7 @@ final class IterableDataReader implements DataReaderInterface
         return $iterable instanceof Traversable ? iterator_to_array($iterable) : $iterable;
     }
 
-    public function getFilter(): ?FilterInterface
+    public function getFilter(): FilterInterface
     {
         return $this->filter;
     }

--- a/tests/Paginator/KeysetPaginatorTest.php
+++ b/tests/Paginator/KeysetPaginatorTest.php
@@ -13,6 +13,7 @@ use Yiisoft\Arrays\ArrayHelper;
 use Yiisoft\Data\Paginator\KeysetFilterContext;
 use Yiisoft\Data\Paginator\KeysetPaginator;
 use Yiisoft\Data\Paginator\PageToken;
+use Yiisoft\Data\Reader\Filter\All;
 use Yiisoft\Data\Reader\Filter\Equals;
 use Yiisoft\Data\Reader\Filter\GreaterThan;
 use Yiisoft\Data\Reader\Filter\GreaterThanOrEqual;
@@ -130,9 +131,9 @@ final class KeysetPaginatorTest extends TestCase
                 return clone $this;
             }
 
-            public function getFilter(): ?FilterInterface
+            public function getFilter(): FilterInterface
             {
-                return null;
+                return new All();
             }
         };
 
@@ -670,9 +671,9 @@ final class KeysetPaginatorTest extends TestCase
                 return clone $this;
             }
 
-            public function getFilter(): ?FilterInterface
+            public function getFilter(): FilterInterface
             {
-                return null;
+                return new All();
             }
 
             public function getLimit(): int

--- a/tests/Reader/Iterable/IterableDataReaderTest.php
+++ b/tests/Reader/Iterable/IterableDataReaderTest.php
@@ -9,6 +9,7 @@ use Generator;
 use InvalidArgumentException;
 use LogicException;
 use Yiisoft\Data\Reader\DataReaderException;
+use Yiisoft\Data\Reader\Filter\All;
 use Yiisoft\Data\Reader\Filter\AndX;
 use Yiisoft\Data\Reader\Filter\OrX;
 use Yiisoft\Data\Reader\Filter\Equals;
@@ -69,7 +70,7 @@ final class IterableDataReaderTest extends TestCase
         $reader = new IterableDataReader([]);
 
         $this->assertNotSame($reader, $reader->withAddedFilterHandlers());
-        $this->assertNotSame($reader, $reader->withFilter(null));
+        $this->assertNotSame($reader, $reader->withFilter(new All()));
         $this->assertNotSame($reader, $reader->withSort(null));
         $this->assertNotSame($reader, $reader->withOffset(1));
         $this->assertNotSame($reader, $reader->withLimit(1));

--- a/tests/Support/MutationDataReader.php
+++ b/tests/Support/MutationDataReader.php
@@ -26,7 +26,7 @@ final class MutationDataReader implements
     ) {
     }
 
-    public function withFilter(?FilterInterface $filter): static
+    public function withFilter(FilterInterface $filter): static
     {
         $new = clone $this;
         $new->decorated = $this->decorated->withFilter($filter);
@@ -69,7 +69,7 @@ final class MutationDataReader implements
         return $this->decorated->getSort();
     }
 
-    public function getFilter(): ?FilterInterface
+    public function getFilter(): FilterInterface
     {
         return $this->decorated->getFilter();
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ✔️
